### PR TITLE
Handle edge case on scheduled invalid transactions, with SCR outcome

### DIFF
--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -136,7 +136,7 @@ func findInvalidTransactions(block *api.Block) []*transaction.ApiTransactionResu
 
 // Sometimes, an invalid transaction processed in a scheduled miniblock
 // might have its smart contract result (if any) saved in the receipts unit of both blocks N and N+1.
-// This function removes the duplicate entries in block N.
+// This function ignores the duplicate entries in block N.
 func deduplicatePreviouslyAppearingContractResults(previousBlock *api.Block, block *api.Block) {
 	previouslyAppearingContractResultsHashes := make(map[string]struct{})
 

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -138,8 +138,8 @@ func findInvalidTransactions(block *api.Block) []*transaction.ApiTransactionResu
 // might have its smart contract result (if any) saved in the receipts unit of both blocks N and N+1.
 // This function ignores the duplicate entries in block N.
 func deduplicatePreviouslyAppearingContractResultsInReceipts(previousBlock *api.Block, block *api.Block) {
-	previouslyAppearingContractResultsHashes := findContractResultsInReceipts(previousBlock)
-	removeContractResultsInReceipts(block, previouslyAppearingContractResultsHashes)
+	previouslyAppearing := findContractResultsInReceipts(previousBlock)
+	removeContractResultsInReceipts(block, previouslyAppearing)
 }
 
 func findContractResultsInReceipts(block *api.Block) map[string]struct{} {

--- a/server/provider/scheduledMiniblocks.go
+++ b/server/provider/scheduledMiniblocks.go
@@ -140,6 +140,7 @@ func findInvalidTransactions(block *api.Block) []*transaction.ApiTransactionResu
 func deduplicatePreviouslyAppearingContractResults(previousBlock *api.Block, block *api.Block) {
 	previouslyAppearingContractResultsHashes := make(map[string]struct{})
 
+	// First, gather the hashes of SCRs in "Normal" miniblocks, in block N-1.
 	for _, miniblock := range previousBlock.MiniBlocks {
 		isResultsMiniblock := miniblock.Type == dataBlock.SmartContractResultBlock.String()
 		isNormalMiniblock := miniblock.ProcessingType == dataBlock.Normal.String()
@@ -154,6 +155,7 @@ func deduplicatePreviouslyAppearingContractResults(previousBlock *api.Block, blo
 		}
 	}
 
+	// Now, remove the duplicate entries in block N.
 	for _, miniblock := range block.MiniBlocks {
 		isResultsMiniblock := miniblock.Type == dataBlock.SmartContractResultBlock.String()
 		isNormalMiniblock := miniblock.ProcessingType == dataBlock.Normal.String()

--- a/version/constants.go
+++ b/version/constants.go
@@ -7,5 +7,5 @@ const (
 
 var (
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.4.0"
+	RosettaMiddlewareVersion = "v0.4.1"
 )


### PR DESCRIPTION
Sometimes, an invalid transaction processed in a _scheduled_ miniblock might have its smart contract result (if any) saved in the _receipts unit_ of both blocks `N` and `N+1`. This PR ignores the duplicate entries in block `N`, as returned by the Node API.

This issue is non-problematic, but, if not fixed, would result into some reconciliation failiures, for accounts that craft more exotic transactions (not simple transfer ones).