### PR TITLE
Receive custom currencies as CLI arg. Refactor, define a "CurrenciesProvider"

### DIFF
--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -137,6 +137,12 @@ VERSION:
 		Usage:    "Provides a hint for the number of historical epochs to be kept.",
 		Required: true,
 	}
+
+	cliFlagCustomCurrenciesSymbols = cli.StringSliceFlag{
+		Name:  "custom-currencies",
+		Usage: "Specifies the symbols of enabled custom currencies (i.e. ESDT identifiers).",
+		Value: &cli.StringSlice{},
+	}
 )
 
 func getAllCliFlags() []cli.Flag {
@@ -160,6 +166,7 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagNativeCurrencySymbol,
 		cliFlagFirstHistoricalEpoch,
 		cliFlagNumHistoricalEpochs,
+		cliFlagCustomCurrenciesSymbols,
 	}
 }
 
@@ -184,6 +191,7 @@ type parsedCliFlags struct {
 	nativeCurrencySymbol        string
 	firstHistoricalEpoch        uint32
 	numHistoricalEpochs         uint32
+	customCurrenciesSymbols     []string
 }
 
 func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
@@ -208,5 +216,6 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		nativeCurrencySymbol:        ctx.GlobalString(cliFlagNativeCurrencySymbol.Name),
 		firstHistoricalEpoch:        uint32(ctx.GlobalUint(cliFlagFirstHistoricalEpoch.Name)),
 		numHistoricalEpochs:         uint32(ctx.GlobalUint(cliFlagNumHistoricalEpochs.Name)),
+		customCurrenciesSymbols:     ctx.GlobalStringSlice(cliFlagCustomCurrenciesSymbols.Name),
 	}
 }

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -69,6 +69,7 @@ func startRosetta(ctx *cli.Context) error {
 		MinGasPrice:                 cliFlags.minGasPrice,
 		MinGasLimit:                 cliFlags.minGasLimit,
 		NativeCurrencySymbol:        cliFlags.nativeCurrencySymbol,
+		CustomCurrenciesSymbols:     cliFlags.customCurrenciesSymbols,
 		GenesisBlockHash:            cliFlags.genesisBlock,
 		FirstHistoricalEpoch:        cliFlags.firstHistoricalEpoch,
 		NumHistoricalEpochs:         cliFlags.numHistoricalEpochs,

--- a/server/factory/interface.go
+++ b/server/factory/interface.go
@@ -13,7 +13,10 @@ import (
 type NetworkProvider interface {
 	IsOffline() bool
 	GetBlockchainName() string
-	GetNativeCurrency() resources.NativeCurrency
+	GetNativeCurrency() resources.Currency
+	GetCustomCurrencies() []resources.Currency
+	GetCustomCurrencyBySymbol(symbol string) (resources.Currency, bool)
+	HasCustomCurrency(symbol string) bool
 	GetNetworkConfig() *resources.NetworkConfig
 	GetGenesisBlockSummary() *resources.BlockSummary
 	GetGenesisTimestamp() int64

--- a/server/factory/provider.go
+++ b/server/factory/provider.go
@@ -38,6 +38,7 @@ type ArgsCreateNetworkProvider struct {
 	MinGasPrice                 uint64
 	MinGasLimit                 uint64
 	NativeCurrencySymbol        string
+	CustomCurrenciesSymbols     []string
 	GenesisBlockHash            string
 	GenesisTimestamp            int64
 	FirstHistoricalEpoch        uint32
@@ -124,6 +125,7 @@ func CreateNetworkProvider(args ArgsCreateNetworkProvider) (NetworkProvider, err
 		MinGasPrice:                 args.MinGasPrice,
 		MinGasLimit:                 args.MinGasLimit,
 		NativeCurrencySymbol:        args.NativeCurrencySymbol,
+		CustomCurrenciesSymbols:     args.CustomCurrenciesSymbols,
 		GenesisBlockHash:            args.GenesisBlockHash,
 		GenesisTimestamp:            args.GenesisTimestamp,
 		FirstHistoricalEpoch:        args.FirstHistoricalEpoch,

--- a/server/provider/currenciesProvider.go
+++ b/server/provider/currenciesProvider.go
@@ -38,24 +38,29 @@ func newCurrenciesProvider(nativeCurrencySymbol string, customCurrenciesSymbols 
 	}
 }
 
-func (provider *currenciesProvider) getNativeCurrency() resources.Currency {
+// GetNativeCurrency gets the native currency (EGLD, 18 decimals)
+func (provider *currenciesProvider) GetNativeCurrency() resources.Currency {
 	return provider.nativeCurrency
 }
 
-func (provider *currenciesProvider) getCustomCurrenciesSymbols() []string {
-	return provider.customCurrenciesSymbols
-}
-
-func (provider *currenciesProvider) getCustomCurrencies() []resources.Currency {
+// GetCustomCurrencies gets the enabled custom currencies (ESDTs)
+func (provider *currenciesProvider) GetCustomCurrencies() []resources.Currency {
 	return provider.customCurrencies
 }
 
-func (provider *currenciesProvider) getCustomCurrencyBySymbol(symbol string) (resources.Currency, bool) {
+// GetCustomCurrencyBySymbol gets a custom currency (ESDT) by symbol (identifier)
+func (provider *currenciesProvider) GetCustomCurrenciesSymbols() []string {
+	return provider.customCurrenciesSymbols
+}
+
+// GetCustomCurrencyBySymbol gets a custom currency (ESDT) by symbol (identifier)
+func (provider *currenciesProvider) GetCustomCurrencyBySymbol(symbol string) (resources.Currency, bool) {
 	currency, ok := provider.customCurrenciesBySymbol[symbol]
 	return currency, ok
 }
 
-func (provider *currenciesProvider) hasCustomCurrency(symbol string) bool {
+// HasCustomCurrency checks whether a custom currency (ESDT) is enabled (supported)
+func (provider *currenciesProvider) HasCustomCurrency(symbol string) bool {
 	_, ok := provider.customCurrenciesBySymbol[symbol]
 	return ok
 }

--- a/server/provider/currenciesProvider.go
+++ b/server/provider/currenciesProvider.go
@@ -1,0 +1,61 @@
+package provider
+
+import "github.com/multiversx/mx-chain-rosetta/server/resources"
+
+type currenciesProvider struct {
+	nativeCurrency           resources.Currency
+	customCurrenciesSymbols  []string
+	customCurrencies         []resources.Currency
+	customCurrenciesBySymbol map[string]resources.Currency
+}
+
+// In the future, we might extract this to a standalone component (separate sub-package).
+// For the moment, we keep it as a simple structure, with unexported (future-to-be exported) member functions.
+func newCurrenciesProvider(nativeCurrencySymbol string, customCurrenciesSymbols []string) *currenciesProvider {
+	customCurrencies := make([]resources.Currency, 0, len(customCurrenciesSymbols))
+	customCurrenciesBySymbol := make(map[string]resources.Currency)
+
+	for _, symbol := range customCurrenciesSymbols {
+		customCurrency := resources.Currency{
+			Symbol: symbol,
+			// At the moment, for custom currencies (ESDTs), we hardcode the number of decimals to 0.
+			// In the future, we might fetch the actual number of decimals from the metachain observer.
+			Decimals: 0,
+		}
+
+		customCurrencies = append(customCurrencies, customCurrency)
+		customCurrenciesBySymbol[symbol] = customCurrency
+	}
+
+	return &currenciesProvider{
+		nativeCurrency: resources.Currency{
+			Symbol:   nativeCurrencySymbol,
+			Decimals: int32(nativeCurrencyNumDecimals),
+		},
+		customCurrenciesSymbols:  customCurrenciesSymbols,
+		customCurrencies:         customCurrencies,
+		customCurrenciesBySymbol: customCurrenciesBySymbol,
+	}
+}
+
+func (provider *currenciesProvider) getNativeCurrency() resources.Currency {
+	return provider.nativeCurrency
+}
+
+func (provider *currenciesProvider) getCustomCurrenciesSymbols() []string {
+	return provider.customCurrenciesSymbols
+}
+
+func (provider *currenciesProvider) getCustomCurrencies() []resources.Currency {
+	return provider.customCurrencies
+}
+
+func (provider *currenciesProvider) getCustomCurrencyBySymbol(symbol string) (resources.Currency, bool) {
+	currency, ok := provider.customCurrenciesBySymbol[symbol]
+	return currency, ok
+}
+
+func (provider *currenciesProvider) hasCustomCurrency(symbol string) bool {
+	_, ok := provider.customCurrenciesBySymbol[symbol]
+	return ok
+}

--- a/server/provider/currenciesProvider_test.go
+++ b/server/provider/currenciesProvider_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrenciesProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newCurrenciesProvider("XeGLD", []string{"ROSETTA-3a2edf", "ROSETTA-057ab4"})
+
+	t.Run("get native", func(t *testing.T) {
+		t.Parallel()
+
+		nativeCurrency := provider.getNativeCurrency()
+		require.Equal(t, "XeGLD", nativeCurrency.Symbol)
+		require.Equal(t, int32(18), nativeCurrency.Decimals)
+	})
+
+	t.Run("get custom", func(t *testing.T) {
+		t.Parallel()
+
+		customCurrencies := provider.getCustomCurrencies()
+		require.Equal(t, 2, len(customCurrencies))
+
+		customCurrency, ok := provider.getCustomCurrencyBySymbol("ROSETTA-3a2edf")
+		require.True(t, ok)
+		require.Equal(t, "ROSETTA-3a2edf", customCurrency.Symbol)
+
+		customCurrency, ok = provider.getCustomCurrencyBySymbol("ROSETTA-057ab4")
+		require.True(t, ok)
+		require.Equal(t, "ROSETTA-057ab4", customCurrency.Symbol)
+
+		customCurrenciesSymbols := provider.getCustomCurrenciesSymbols()
+		require.Equal(t, 2, len(customCurrenciesSymbols))
+		require.Equal(t, "ROSETTA-3a2edf", customCurrenciesSymbols[0])
+		require.Equal(t, "ROSETTA-057ab4", customCurrenciesSymbols[1])
+	})
+
+	t.Run("has custom", func(t *testing.T) {
+		t.Parallel()
+
+		require.True(t, provider.hasCustomCurrency("ROSETTA-3a2edf"))
+		require.True(t, provider.hasCustomCurrency("ROSETTA-057ab4"))
+		require.False(t, provider.hasCustomCurrency("FOO-abcdef"))
+		require.False(t, provider.hasCustomCurrency("BAR-abcdef"))
+	})
+}

--- a/server/provider/currenciesProvider_test.go
+++ b/server/provider/currenciesProvider_test.go
@@ -14,7 +14,7 @@ func TestCurrenciesProvider(t *testing.T) {
 	t.Run("get native", func(t *testing.T) {
 		t.Parallel()
 
-		nativeCurrency := provider.getNativeCurrency()
+		nativeCurrency := provider.GetNativeCurrency()
 		require.Equal(t, "XeGLD", nativeCurrency.Symbol)
 		require.Equal(t, int32(18), nativeCurrency.Decimals)
 	})
@@ -22,18 +22,18 @@ func TestCurrenciesProvider(t *testing.T) {
 	t.Run("get custom", func(t *testing.T) {
 		t.Parallel()
 
-		customCurrencies := provider.getCustomCurrencies()
+		customCurrencies := provider.GetCustomCurrencies()
 		require.Equal(t, 2, len(customCurrencies))
 
-		customCurrency, ok := provider.getCustomCurrencyBySymbol("ROSETTA-3a2edf")
+		customCurrency, ok := provider.GetCustomCurrencyBySymbol("ROSETTA-3a2edf")
 		require.True(t, ok)
 		require.Equal(t, "ROSETTA-3a2edf", customCurrency.Symbol)
 
-		customCurrency, ok = provider.getCustomCurrencyBySymbol("ROSETTA-057ab4")
+		customCurrency, ok = provider.GetCustomCurrencyBySymbol("ROSETTA-057ab4")
 		require.True(t, ok)
 		require.Equal(t, "ROSETTA-057ab4", customCurrency.Symbol)
 
-		customCurrenciesSymbols := provider.getCustomCurrenciesSymbols()
+		customCurrenciesSymbols := provider.GetCustomCurrenciesSymbols()
 		require.Equal(t, 2, len(customCurrenciesSymbols))
 		require.Equal(t, "ROSETTA-3a2edf", customCurrenciesSymbols[0])
 		require.Equal(t, "ROSETTA-057ab4", customCurrenciesSymbols[1])
@@ -42,9 +42,9 @@ func TestCurrenciesProvider(t *testing.T) {
 	t.Run("has custom", func(t *testing.T) {
 		t.Parallel()
 
-		require.True(t, provider.hasCustomCurrency("ROSETTA-3a2edf"))
-		require.True(t, provider.hasCustomCurrency("ROSETTA-057ab4"))
-		require.False(t, provider.hasCustomCurrency("FOO-abcdef"))
-		require.False(t, provider.hasCustomCurrency("BAR-abcdef"))
+		require.True(t, provider.HasCustomCurrency("ROSETTA-3a2edf"))
+		require.True(t, provider.HasCustomCurrency("ROSETTA-057ab4"))
+		require.False(t, provider.HasCustomCurrency("FOO-abcdef"))
+		require.False(t, provider.HasCustomCurrency("BAR-abcdef"))
 	})
 }

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -48,6 +48,8 @@ type ArgsNewNetworkProvider struct {
 
 // In the future, we might rename this to "networkFacade" (which, in turn, depends on networkProvider, currencyProvider, blocksProvider and so on).
 type networkProvider struct {
+	*currenciesProvider
+
 	isOffline                   bool
 	observedActualShard         uint32
 	observedProjectedShard      uint32
@@ -58,8 +60,7 @@ type networkProvider struct {
 	firstHistoricalEpoch        uint32
 	numHistoricalEpochs         uint32
 
-	currenciesProvider *currenciesProvider
-	observerFacade     observerFacade
+	observerFacade observerFacade
 
 	hasher                hashing.Hasher
 	marshalizerForHashing marshal.Marshalizer
@@ -82,6 +83,8 @@ func NewNetworkProvider(args ArgsNewNetworkProvider) (*networkProvider, error) {
 	currenciesProvider := newCurrenciesProvider(args.NativeCurrencySymbol, args.CustomCurrenciesSymbols)
 
 	return &networkProvider{
+		currenciesProvider: currenciesProvider,
+
 		isOffline: args.IsOffline,
 
 		observedActualShard:         args.ObservedActualShard,
@@ -93,8 +96,7 @@ func NewNetworkProvider(args ArgsNewNetworkProvider) (*networkProvider, error) {
 		firstHistoricalEpoch:        args.FirstHistoricalEpoch,
 		numHistoricalEpochs:         args.NumHistoricalEpochs,
 
-		currenciesProvider: currenciesProvider,
-		observerFacade:     args.ObserverFacade,
+		observerFacade: args.ObserverFacade,
 
 		hasher:                args.Hasher,
 		marshalizerForHashing: args.MarshalizerForHashing,
@@ -121,26 +123,6 @@ func (provider *networkProvider) IsOffline() bool {
 // GetBlockchainName returns the name of the network
 func (provider *networkProvider) GetBlockchainName() string {
 	return provider.networkConfig.BlockchainName
-}
-
-// GetNativeCurrency gets the native currency (EGLD, 18 decimals)
-func (provider *networkProvider) GetNativeCurrency() resources.Currency {
-	return provider.currenciesProvider.getNativeCurrency()
-}
-
-// GetCustomCurrencies gets the enabled custom currencies (ESDTs)
-func (provider *networkProvider) GetCustomCurrencies() []resources.Currency {
-	return provider.currenciesProvider.getCustomCurrencies()
-}
-
-// GetCustomCurrencyBySymbol gets a custom currency (ESDT) by symbol (identifier)
-func (provider *networkProvider) GetCustomCurrencyBySymbol(symbol string) (resources.Currency, bool) {
-	return provider.currenciesProvider.getCustomCurrencyBySymbol(symbol)
-}
-
-// HasCustomCurrency checks whether a custom currency (ESDT) is enabled (supported)
-func (provider *networkProvider) HasCustomCurrency(symbol string) bool {
-	return provider.currenciesProvider.hasCustomCurrency(symbol)
 }
 
 // GetNetworkConfig gets the network config (once fetched, the network config is indefinitely held in memory)
@@ -433,7 +415,7 @@ func (provider *networkProvider) LogDescription() {
 		"observedProjectedShardIsSet", provider.observedProjectedShardIsSet,
 		"firstHistoricalEpoch", provider.firstHistoricalEpoch,
 		"numHistoricalEpochs", provider.numHistoricalEpochs,
-		"nativeCurrency", provider.currenciesProvider.getNativeCurrency().Symbol,
-		"customCurrencies", provider.currenciesProvider.getCustomCurrenciesSymbols(),
+		"nativeCurrency", provider.GetNativeCurrency().Symbol,
+		"customCurrencies", provider.GetCustomCurrenciesSymbols(),
 	)
 }

--- a/server/provider/networkProvider_test.go
+++ b/server/provider/networkProvider_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/api"
 	"github.com/multiversx/mx-chain-proxy-go/common"
 	"github.com/multiversx/mx-chain-proxy-go/data"
+	"github.com/multiversx/mx-chain-rosetta/server/resources"
 	"github.com/multiversx/mx-chain-rosetta/testscommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,7 @@ func TestNewNetworkProvider(t *testing.T) {
 		MinGasPrice:                 1000000001,
 		MinGasLimit:                 50001,
 		NativeCurrencySymbol:        "XeGLD",
+		CustomCurrenciesSymbols:     []string{"FOO-abcdef", "BAR-abcdef"},
 		GenesisBlockHash:            "aaaa",
 		GenesisTimestamp:            123456789,
 		FirstHistoricalEpoch:        1000,
@@ -51,6 +53,7 @@ func TestNewNetworkProvider(t *testing.T) {
 	assert.Equal(t, uint64(1000000001), provider.GetNetworkConfig().MinGasPrice)
 	assert.Equal(t, uint64(50001), provider.GetNetworkConfig().MinGasLimit)
 	assert.Equal(t, "XeGLD", provider.GetNativeCurrency().Symbol)
+	assert.Equal(t, []resources.Currency{{Symbol: "FOO-abcdef"}, {Symbol: "BAR-abcdef"}}, provider.GetCustomCurrencies())
 	assert.Equal(t, "aaaa", provider.GetGenesisBlockSummary().Hash)
 	assert.Equal(t, int64(123456789), provider.GetGenesisTimestamp())
 	assert.Equal(t, uint32(1000), provider.firstHistoricalEpoch)

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -20,8 +20,8 @@ type BlockSummary struct {
 	Timestamp         int64
 }
 
-// NativeCurrency is an internal resource
-type NativeCurrency struct {
+// Currency is an internal resource
+type Currency struct {
 	Symbol   string
 	Decimals int32
 }

--- a/server/services/interface.go
+++ b/server/services/interface.go
@@ -12,7 +12,10 @@ import (
 type NetworkProvider interface {
 	IsOffline() bool
 	GetBlockchainName() string
-	GetNativeCurrency() resources.NativeCurrency
+	GetNativeCurrency() resources.Currency
+	GetCustomCurrencies() []resources.Currency
+	GetCustomCurrencyBySymbol(symbol string) (resources.Currency, bool)
+	HasCustomCurrency(symbol string) bool
 	GetNetworkConfig() *resources.NetworkConfig
 	GetGenesisBlockSummary() *resources.BlockSummary
 	GetGenesisTimestamp() int64

--- a/testscommon/networkProviderMock.go
+++ b/testscommon/networkProviderMock.go
@@ -28,6 +28,7 @@ type networkProviderMock struct {
 	MockObservedProjectedShard      uint32
 	MockObservedProjectedShardIsSet bool
 	MockNativeCurrencySymbol        string
+	MockCustomCurrencies            []resources.Currency
 	MockGenesisBlockHash            string
 	MockGenesisTimestamp            int64
 	MockNetworkConfig               *resources.NetworkConfig
@@ -59,6 +60,7 @@ func NewNetworkProviderMock() *networkProviderMock {
 		MockObservedProjectedShard:      0,
 		MockObservedProjectedShardIsSet: false,
 		MockNativeCurrencySymbol:        "XeGLD",
+		MockCustomCurrencies:            make([]resources.Currency, 0),
 		MockGenesisBlockHash:            emptyHash,
 		MockGenesisTimestamp:            genesisTimestamp,
 		MockNetworkConfig: &resources.NetworkConfig{
@@ -112,11 +114,33 @@ func (mock *networkProviderMock) GetBlockchainName() string {
 }
 
 // GetNativeCurrency -
-func (mock *networkProviderMock) GetNativeCurrency() resources.NativeCurrency {
-	return resources.NativeCurrency{
+func (mock *networkProviderMock) GetNativeCurrency() resources.Currency {
+	return resources.Currency{
 		Symbol:   mock.MockNativeCurrencySymbol,
 		Decimals: 18,
 	}
+}
+
+// GetCustomCurrencies -
+func (mock *networkProviderMock) GetCustomCurrencies() []resources.Currency {
+	return mock.MockCustomCurrencies
+}
+
+// GetCustomCurrencyBySymbol -
+func (mock *networkProviderMock) GetCustomCurrencyBySymbol(symbol string) (resources.Currency, bool) {
+	for _, currency := range mock.MockCustomCurrencies {
+		if currency.Symbol == symbol {
+			return currency, true
+		}
+	}
+
+	return resources.Currency{}, false
+}
+
+// HasCustomCurrency -
+func (mock *networkProviderMock) HasCustomCurrency(symbol string) bool {
+	_, has := mock.GetCustomCurrencyBySymbol(symbol)
+	return has
 }
 
 // GetNetworkConfig -


### PR DESCRIPTION
New CLI arg, `custom-currencies`. E.g.:

```
rosetta [...]
    --custom-currencies=ROSETTA-3a2edf
    --custom-currencies=ROSETTA-057ab4
```

Additional refactoring.