### PR TITLE
Add converters - to be used in ESDT transfer construction (and parsing)

### DIFF
--- a/server/services/constructionServiceFee_test.go
+++ b/server/services/constructionServiceFee_test.go
@@ -126,7 +126,7 @@ func TestConstructionService_ComputeFeeComponents_ForCustomTokenTransfers(t *tes
 		require.Equal(t, uint64(0), gasPrice)
 	})
 
-	t.Run("custom transfer (with explicit, with more gas limit than necessary)", func(t *testing.T) {
+	t.Run("custom transfer (with explicit gas limit, but insufficient)", func(t *testing.T) {
 		fee, gasLimit, gasPrice, err := service.computeFeeComponents(&constructionOptions{
 			GasLimit:       10000000,
 			GasPrice:       1000000000,

--- a/server/services/constructionServiceFee_test.go
+++ b/server/services/constructionServiceFee_test.go
@@ -113,7 +113,7 @@ func TestConstructionService_ComputeFeeComponents_ForCustomTokenTransfers(t *tes
 		require.Equal(t, uint64(1000000000), gasPrice)
 	})
 
-	t.Run("custom transfer (with explicit, but insufficient gas limit)", func(t *testing.T) {
+	t.Run("custom transfer (with explicit gas limit, but insufficient)", func(t *testing.T) {
 		fee, gasLimit, gasPrice, err := service.computeFeeComponents(&constructionOptions{
 			GasLimit:       100000,
 			GasPrice:       1000000000,
@@ -126,7 +126,7 @@ func TestConstructionService_ComputeFeeComponents_ForCustomTokenTransfers(t *tes
 		require.Equal(t, uint64(0), gasPrice)
 	})
 
-	t.Run("custom transfer (with explicit gas limit, but insufficient)", func(t *testing.T) {
+	t.Run("custom transfer (with explicit gas limit, more than necessary)", func(t *testing.T) {
 		fee, gasLimit, gasPrice, err := service.computeFeeComponents(&constructionOptions{
 			GasLimit:       10000000,
 			GasPrice:       1000000000,

--- a/server/services/converters.go
+++ b/server/services/converters.go
@@ -72,7 +72,7 @@ func timestampInMilliseconds(timestamp int64) int64 {
 	return timestamp * 1000
 }
 
-func utf8ToHex(value string) string {
+func stringToHex(value string) string {
 	encoded := hex.EncodeToString([]byte(value))
 	encoded = ensureEvenLengthOfHexString(encoded)
 	return encoded
@@ -104,6 +104,5 @@ func hexToAmount(hexString string) (string, error) {
 	}
 
 	amountBig := big.NewInt(0).SetBytes(amountBytes)
-	amount := amountBig.String()
-	return amount, nil
+	return amountBig.String(), nil
 }

--- a/server/services/converters.go
+++ b/server/services/converters.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/hex"
+	"math/big"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/multiversx/mx-chain-core-go/data/api"
@@ -69,4 +70,40 @@ func indexToOperationIdentifier(index int) *types.OperationIdentifier {
 
 func timestampInMilliseconds(timestamp int64) int64 {
 	return timestamp * 1000
+}
+
+func utf8ToHex(value string) string {
+	encoded := hex.EncodeToString([]byte(value))
+	encoded = ensureEvenLengthOfHexString(encoded)
+	return encoded
+}
+
+func ensureEvenLengthOfHexString(hexString string) string {
+	if len(hexString)%2 == 1 {
+		return "0" + hexString
+	}
+
+	return hexString
+}
+
+func amountToHex(value string) string {
+	bigAmount, ok := big.NewInt(0).SetString(value, 10)
+	if !ok {
+		return ""
+	}
+
+	encoded := hex.EncodeToString(bigAmount.Bytes())
+	encoded = ensureEvenLengthOfHexString(encoded)
+	return encoded
+}
+
+func hexToAmount(hexString string) (string, error) {
+	amountBytes, err := hex.DecodeString(hexString)
+	if err != nil {
+		return "", err
+	}
+
+	amountBig := big.NewInt(0).SetBytes(amountBytes)
+	amount := amountBig.String()
+	return amount, nil
 }

--- a/server/services/converters.go
+++ b/server/services/converters.go
@@ -89,6 +89,7 @@ func ensureEvenLengthOfHexString(hexString string) string {
 func amountToHex(value string) string {
 	bigAmount, ok := big.NewInt(0).SetString(value, 10)
 	if !ok {
+		log.Warn("amountToHex(): amount is not a number", "amount", value)
 		return ""
 	}
 

--- a/server/services/converters_test.go
+++ b/server/services/converters_test.go
@@ -35,8 +35,9 @@ func TestBlockIdentifierToAccountQueryOptions(t *testing.T) {
 }
 
 func TestUtf8ToHex(t *testing.T) {
-	require.Equal(t, "68656c6c6f", utf8ToHex("hello"))
-	require.Equal(t, "776f726c64", utf8ToHex("world"))
+	require.Equal(t, "68656c6c6f", stringToHex("hello"))
+	require.Equal(t, "776f726c64", stringToHex("world"))
+	require.Equal(t, "0a", stringToHex("\n"))
 }
 
 func TestAmountToHex(t *testing.T) {

--- a/server/services/converters_test.go
+++ b/server/services/converters_test.go
@@ -33,3 +33,33 @@ func TestBlockIdentifierToAccountQueryOptions(t *testing.T) {
 		require.ErrorContains(t, err, "encoding/hex: invalid byte")
 	})
 }
+
+func TestUtf8ToHex(t *testing.T) {
+	require.Equal(t, "68656c6c6f", utf8ToHex("hello"))
+	require.Equal(t, "776f726c64", utf8ToHex("world"))
+}
+
+func TestAmountToHex(t *testing.T) {
+	require.Equal(t, "", amountToHex("0"))
+	require.Equal(t, "07", amountToHex("7"))
+	require.Equal(t, "2a", amountToHex("42"))
+	require.Equal(t, "64", amountToHex("100"))
+}
+
+func TestHexToAmount(t *testing.T) {
+	amount, err := hexToAmount("00")
+	require.Nil(t, err)
+	require.Equal(t, "0", amount)
+
+	amount, err = hexToAmount("07")
+	require.Nil(t, err)
+	require.Equal(t, "7", amount)
+
+	amount, err = hexToAmount("2a")
+	require.Nil(t, err)
+	require.Equal(t, "42", amount)
+
+	amount, err = hexToAmount("64")
+	require.Nil(t, err)
+	require.Equal(t, "100", amount)
+}


### PR DESCRIPTION
Add a few converters, to be used for creating (and parsing) ESDT transfers - in a following PR.