### PR TITLE
Handle intra-shard relayed transactions with signal error

### DIFF
--- a/server/factory/components/observerFacade.go
+++ b/server/factory/components/observerFacade.go
@@ -12,6 +12,7 @@ type ObserverFacade struct {
 	facade.BlockProcessor
 }
 
+// ComputeShardId computes the shard ID for a given public key
 func (facade *ObserverFacade) ComputeShardId(pubKey []byte) uint32 {
 	return facade.GetShardCoordinator().ComputeId(pubKey)
 }

--- a/server/factory/components/observerFacade.go
+++ b/server/factory/components/observerFacade.go
@@ -11,3 +11,7 @@ type ObserverFacade struct {
 	facade.TransactionProcessor
 	facade.BlockProcessor
 }
+
+func (facade *ObserverFacade) ComputeShardId(pubKey []byte) uint32 {
+	return facade.GetShardCoordinator().ComputeId(pubKey)
+}

--- a/server/factory/interface.go
+++ b/server/factory/interface.go
@@ -25,6 +25,7 @@ type NetworkProvider interface {
 	GetAccountNativeBalance(address string, options resources.AccountQueryOptions) (*resources.AccountOnBlock, error)
 	GetAccountESDTBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) (*resources.AccountESDTBalance, error)
 	IsAddressObserved(address string) (bool, error)
+	ComputeShardIdOfPubKey(pubkey []byte) uint32
 	ConvertPubKeyToAddress(pubkey []byte) string
 	ConvertAddressToPubKey(address string) ([]byte, error)
 	SendTransaction(tx *data.Transaction) (string, error)

--- a/server/provider/interface.go
+++ b/server/provider/interface.go
@@ -8,7 +8,7 @@ import (
 
 type observerFacade interface {
 	CallGetRestEndPoint(baseUrl string, path string, value interface{}) (int, error)
-	ComputeShardId(pubKey []byte) (uint32, error)
+	ComputeShardId(pubKey []byte) uint32
 	SendTransaction(tx *data.Transaction) (int, string, error)
 	ComputeTransactionHash(tx *data.Transaction) (string, error)
 	GetTransactionByHashAndSenderAddress(hash string, sender string, withEvents bool) (*transaction.ApiTransactionResult, int, error)

--- a/server/provider/networkProvider.go
+++ b/server/provider/networkProvider.go
@@ -305,11 +305,7 @@ func (provider *networkProvider) IsAddressObserved(address string) (bool, error)
 		return false, err
 	}
 
-	shard, err := provider.observerFacade.ComputeShardId(pubKey)
-	if err != nil {
-		return false, err
-	}
-
+	shard := provider.observerFacade.ComputeShardId(pubKey)
 	isObservedActualShard := shard == provider.observedActualShard
 	isObservedProjectedShard := pubKey[len(pubKey)-1] == byte(provider.observedProjectedShard)
 
@@ -318,6 +314,12 @@ func (provider *networkProvider) IsAddressObserved(address string) (bool, error)
 	}
 
 	return isObservedActualShard, nil
+}
+
+// ComputeShardIdOfPubKey computes the shard ID of a public key
+func (provider *networkProvider) ComputeShardIdOfPubKey(pubKey []byte) uint32 {
+	shard := provider.observerFacade.ComputeShardId(pubKey)
+	return shard
 }
 
 // ConvertPubKeyToAddress converts a public key to an address

--- a/server/provider/networkProvider_test.go
+++ b/server/provider/networkProvider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
@@ -165,6 +166,22 @@ func TestNetworkProvider_DoGetBlockByNonce(t *testing.T) {
 		require.False(t, &block == &cachedBlock)
 		require.Equal(t, 1, provider.blocksCache.Len())
 	})
+}
+
+func Test_ComputeShardIdOfPubKey(t *testing.T) {
+	args := createDefaultArgsNewNetworkProvider()
+	provider, err := NewNetworkProvider(args)
+	require.Nil(t, err)
+	require.NotNil(t, provider)
+
+	pubKey, _ := hex.DecodeString("8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8")
+	require.Equal(t, uint32(0), provider.ComputeShardIdOfPubKey(pubKey))
+
+	pubKey, _ = hex.DecodeString("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1")
+	require.Equal(t, uint32(1), provider.ComputeShardIdOfPubKey(pubKey))
+
+	pubKey, _ = hex.DecodeString("b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba")
+	require.Equal(t, uint32(2), provider.ComputeShardIdOfPubKey(pubKey))
 }
 
 func Test_ComputeTransactionFeeForMoveBalance(t *testing.T) {

--- a/server/provider/networkProvider_test.go
+++ b/server/provider/networkProvider_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
@@ -174,14 +173,9 @@ func Test_ComputeShardIdOfPubKey(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, provider)
 
-	pubKey, _ := hex.DecodeString("8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8")
-	require.Equal(t, uint32(0), provider.ComputeShardIdOfPubKey(pubKey))
-
-	pubKey, _ = hex.DecodeString("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1")
-	require.Equal(t, uint32(1), provider.ComputeShardIdOfPubKey(pubKey))
-
-	pubKey, _ = hex.DecodeString("b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba")
-	require.Equal(t, uint32(2), provider.ComputeShardIdOfPubKey(pubKey))
+	require.Equal(t, uint32(0), provider.ComputeShardIdOfPubKey(testscommon.TestPubKeyBob))
+	require.Equal(t, uint32(1), provider.ComputeShardIdOfPubKey(testscommon.TestPubKeyAlice))
+	require.Equal(t, uint32(2), provider.ComputeShardIdOfPubKey(testscommon.TestPubKeyCarol))
 }
 
 func Test_ComputeTransactionFeeForMoveBalance(t *testing.T) {

--- a/server/services/common.go
+++ b/server/services/common.go
@@ -50,6 +50,14 @@ func isZeroAmount(amount string) bool {
 	return false
 }
 
+func isZeroBigInt(value *big.Int) bool {
+	if value == nil {
+		return true
+	}
+
+	return value.Sign() == 0
+}
+
 func getMagnitudeOfAmount(amount string) string {
 	return strings.Trim(amount, "-")
 }

--- a/server/services/common.go
+++ b/server/services/common.go
@@ -50,7 +50,7 @@ func isZeroAmount(amount string) bool {
 	return false
 }
 
-func isZeroBigInt(value *big.Int) bool {
+func isZeroBigIntOrNil(value *big.Int) bool {
 	if value == nil {
 		return true
 	}

--- a/server/services/common_test.go
+++ b/server/services/common_test.go
@@ -43,10 +43,10 @@ func Test_IsZeroAmount(t *testing.T) {
 }
 
 func Test_IsZeroBigInt(t *testing.T) {
-	require.True(t, isZeroBigInt(big.NewInt(0)))
-	require.True(t, isZeroBigInt(nil))
-	require.False(t, isZeroBigInt(big.NewInt(42)))
-	require.False(t, isZeroBigInt(big.NewInt(-42)))
+	require.True(t, isZeroBigIntOrNil(big.NewInt(0)))
+	require.True(t, isZeroBigIntOrNil(nil))
+	require.False(t, isZeroBigIntOrNil(big.NewInt(42)))
+	require.False(t, isZeroBigIntOrNil(big.NewInt(-42)))
 }
 
 func Test_GetMagnitudeOfAmount(t *testing.T) {

--- a/server/services/common_test.go
+++ b/server/services/common_test.go
@@ -42,6 +42,13 @@ func Test_IsZeroAmount(t *testing.T) {
 	require.False(t, isZeroAmount("-1"))
 }
 
+func Test_IsZeroBigInt(t *testing.T) {
+	require.True(t, isZeroBigInt(big.NewInt(0)))
+	require.True(t, isZeroBigInt(nil))
+	require.False(t, isZeroBigInt(big.NewInt(42)))
+	require.False(t, isZeroBigInt(big.NewInt(-42)))
+}
+
 func Test_GetMagnitudeOfAmount(t *testing.T) {
 	require.Equal(t, "100", getMagnitudeOfAmount("100"))
 	require.Equal(t, "100", getMagnitudeOfAmount("-100"))

--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -3,6 +3,8 @@ package services
 import (
 	"encoding/hex"
 	"strings"
+
+	"github.com/multiversx/mx-chain-core-go/core"
 )
 
 var (
@@ -10,7 +12,7 @@ var (
 	transactionProcessingTypeRelayed             = "RelayedTx"
 	transactionProcessingTypeBuiltInFunctionCall = "BuiltInFunctionCall"
 	transactionProcessingTypeMoveBalance         = "MoveBalance"
-	builtInFunctionClaimDeveloperRewards         = "ClaimDeveloperRewards"
+	builtInFunctionClaimDeveloperRewards         = core.BuiltInFunctionClaimDeveloperRewards
 	refundGasMessage                             = "refundedGas"
 	argumentsSeparator                           = "@"
 	sendingValueToNonPayableContractDataPrefix   = argumentsSeparator + hex.EncodeToString([]byte("sending value to non payable contract"))
@@ -19,7 +21,7 @@ var (
 )
 
 var (
-	transactionEventSignalError                             = "signalError"
+	transactionEventSignalError                             = core.SignalErrorOperation
 	transactionEventTransferValueOnly                       = "transferValueOnly"
 	transactionEventTopicInvalidMetaTransaction             = "meta transaction is invalid"
 	transactionEventTopicInvalidMetaTransactionNotEnoughGas = "meta transaction is invalid: not enough gas"

--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -12,7 +12,8 @@ var (
 	transactionProcessingTypeMoveBalance         = "MoveBalance"
 	builtInFunctionClaimDeveloperRewards         = "ClaimDeveloperRewards"
 	refundGasMessage                             = "refundedGas"
-	sendingValueToNonPayableContractDataPrefix   = "@" + hex.EncodeToString([]byte("sending value to non payable contract"))
+	argumentsSeparator                           = "@"
+	sendingValueToNonPayableContractDataPrefix   = argumentsSeparator + hex.EncodeToString([]byte("sending value to non payable contract"))
 	emptyHash                                    = strings.Repeat("0", 64)
 	nodeVersionForOfflineRosetta                 = "N / A"
 )

--- a/server/services/errors.go
+++ b/server/services/errors.go
@@ -201,3 +201,4 @@ func (factory *errFactory) getPrototypeByCode(code errCode) errPrototype {
 
 var errEventNotFound = errors.New("transaction event not found")
 var errCannotRecognizeEvent = errors.New("cannot recognize transaction event")
+var errCannotParseRelayedV1 = errors.New("cannot parse relayed V1 transaction")

--- a/server/services/interface.go
+++ b/server/services/interface.go
@@ -24,6 +24,7 @@ type NetworkProvider interface {
 	GetAccountNativeBalance(address string, options resources.AccountQueryOptions) (*resources.AccountOnBlock, error)
 	GetAccountESDTBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) (*resources.AccountESDTBalance, error)
 	IsAddressObserved(address string) (bool, error)
+	ComputeShardIdOfPubKey(pubkey []byte) uint32
 	ConvertPubKeyToAddress(pubkey []byte) string
 	ConvertAddressToPubKey(address string) ([]byte, error)
 	SendTransaction(tx *data.Transaction) (string, error)

--- a/server/services/relayedTransactions.go
+++ b/server/services/relayedTransactions.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"strings"
+
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+)
+
+func isRelayedV1Transaction(tx *transaction.ApiTransactionResult) bool {
+	return (tx.Type == string(transaction.TxTypeNormal)) &&
+		(tx.ProcessingTypeOnSource == transactionProcessingTypeRelayed) &&
+		(tx.ProcessingTypeOnDestination == transactionProcessingTypeRelayed)
+}
+

--- a/server/services/relayedTransactions.go
+++ b/server/services/relayedTransactions.go
@@ -9,9 +9,37 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 )
 
+// innerTransactionOfRelayedV1 is used to parse the inner transaction of a relayed V1 transaction, and holds only the fields handled by Rosetta.
+type innerTransactionOfRelayedV1 struct {
+	Nonce          uint64  `json:"nonce"`
+	Value          big.Int `json:"value"`
+	ReceiverPubKey []byte  `json:"receiver"`
+	SenderPubKey   []byte  `json:"sender"`
+}
+
 func isRelayedV1Transaction(tx *transaction.ApiTransactionResult) bool {
 	return (tx.Type == string(transaction.TxTypeNormal)) &&
 		(tx.ProcessingTypeOnSource == transactionProcessingTypeRelayed) &&
 		(tx.ProcessingTypeOnDestination == transactionProcessingTypeRelayed)
 }
 
+func parseInnerTxOfRelayedV1(tx *transaction.ApiTransactionResult) (*innerTransactionOfRelayedV1, error) {
+	subparts := strings.Split(string(tx.Data), argumentsSeparator)
+	if len(subparts) != 2 {
+		return nil, errCannotParseRelayedV1
+	}
+
+	innerTxPayloadDecoded, err := hex.DecodeString(subparts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	var innerTx innerTransactionOfRelayedV1
+
+	err = json.Unmarshal(innerTxPayloadDecoded, &innerTx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &innerTx, nil
+}

--- a/server/services/relayedTransactions_test.go
+++ b/server/services/relayedTransactions_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -21,5 +22,29 @@ func Test_IsRelayedV1Transaction(t *testing.T) {
 		}
 
 		require.True(t, isRelayedV1Transaction(tx))
+	})
+}
+
+func Test_ParseInnerTxOfRelayedV1(t *testing.T) {
+	t.Run("arbitrary tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{}
+		innerTx, err := parseInnerTxOfRelayedV1(tx)
+		require.ErrorIs(t, err, errCannotParseRelayedV1)
+		require.Nil(t, innerTx)
+	})
+
+	t.Run("relayed v1 tx (Alice to Bob, 1 EGLD)", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Data: []byte("relayedTx@7b226e6f6e6365223a372c2273656e646572223a2241546c484c76396f686e63616d433877673970645168386b77704742356a6949496f3349484b594e6165453d222c227265636569766572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a222b4161696451714c4d6150314b4f414d42506a557554774955775137724f6d62586976446c6b4944775a315a48353053366377714a4163576a496a744f732f435177502b79597a6643356730637571526b55437842413d3d222c22636861696e4944223a224d513d3d222c2276657273696f6e223a327d"),
+		}
+
+		innerTx, err := parseInnerTxOfRelayedV1(tx)
+		require.NoError(t, err)
+		require.NotNil(t, innerTx)
+
+		require.Equal(t, uint64(7), innerTx.Nonce)
+		require.Equal(t, "1000000000000000000", innerTx.Value.String())
+		require.Equal(t, "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1", hex.EncodeToString(innerTx.SenderPubKey))
+		require.Equal(t, "8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8", hex.EncodeToString(innerTx.ReceiverPubKey))
 	})
 }

--- a/server/services/relayedTransactions_test.go
+++ b/server/services/relayedTransactions_test.go
@@ -1,10 +1,10 @@
 package services
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-rosetta/testscommon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +44,7 @@ func Test_ParseInnerTxOfRelayedV1(t *testing.T) {
 
 		require.Equal(t, uint64(7), innerTx.Nonce)
 		require.Equal(t, "1000000000000000000", innerTx.Value.String())
-		require.Equal(t, "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1", hex.EncodeToString(innerTx.SenderPubKey))
-		require.Equal(t, "8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8", hex.EncodeToString(innerTx.ReceiverPubKey))
+		require.Equal(t, testscommon.TestPubKeyAlice, innerTx.SenderPubKey)
+		require.Equal(t, testscommon.TestPubKeyBob, innerTx.ReceiverPubKey)
 	})
 }

--- a/server/services/relayedTransactions_test.go
+++ b/server/services/relayedTransactions_test.go
@@ -1,0 +1,25 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IsRelayedV1Transaction(t *testing.T) {
+	t.Run("arbitrary tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{}
+		require.False(t, isRelayedV1Transaction(tx))
+	})
+
+	t.Run("relayed v1 tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Type:                        string(transaction.TxTypeNormal),
+			ProcessingTypeOnSource:      transactionProcessingTypeRelayed,
+			ProcessingTypeOnDestination: transactionProcessingTypeRelayed,
+		}
+
+		require.True(t, isRelayedV1Transaction(tx))
+	})
+}

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -58,6 +58,21 @@ func (controller *transactionEventsController) extractEventTransferValueOnly(tx 
 	}, nil
 }
 
+func (controller *transactionEventsController) hasAnySignalError(tx *transaction.ApiTransactionResult) bool {
+	if !controller.hasEvents(tx) {
+		return false
+	}
+
+	for _, event := range tx.Logs.Events {
+		isSignalError := event.Identifier == transactionEventSignalError
+		if isSignalError {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (controller *transactionEventsController) hasSignalErrorOfSendingValueToNonPayableContract(tx *transaction.ApiTransactionResult) bool {
 	if !controller.hasEvents(tx) {
 		return false

--- a/server/services/transactionEventsController_test.go
+++ b/server/services/transactionEventsController_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTransactionEventsController_HasAnySignalError(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	controller := newTransactionEventsController(networkProvider)
+
+	t.Run("arbitrary tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{}
+		txMatches := controller.hasAnySignalError(tx)
+		require.False(t, txMatches)
+	})
+
+	t.Run("tx with event 'signalError'", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Logs: &transaction.ApiLogs{
+
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+					},
+				},
+			},
+		}
+
+		txMatches := controller.hasAnySignalError(tx)
+		require.True(t, txMatches)
+	})
+}
+
 func TestTransactionEventsController_HasSignalErrorOfSendingValueToNonPayableContract(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()
 	controller := newTransactionEventsController(networkProvider)
@@ -83,6 +110,18 @@ func TestTransactionEventsController_HasSignalErrorOfMetaTransactionIsInvalid(t 
 		txMatches := controller.hasSignalErrorOfMetaTransactionIsInvalid(tx)
 		require.True(t, txMatches)
 	})
+}
+
+func Test(t *testing.T) {
+	event := transaction.Events{
+		Identifier: transactionEventSignalError,
+		Topics: [][]byte{
+			[]byte("foo"),
+		},
+	}
+
+	require.True(t, eventHasTopic(&event, "foo"))
+	require.False(t, eventHasTopic(&event, "bar"))
 }
 
 func TestEventHasTopic(t *testing.T) {

--- a/server/services/transactionFilters.go
+++ b/server/services/transactionFilters.go
@@ -40,10 +40,7 @@ func filterOutIntrashardRelayedTransactionAlreadyHeldInInvalidMiniblock(txs []*t
 	}
 
 	for _, tx := range txs {
-		isRelayedTransaction := (tx.Type == string(transaction.TxTypeNormal)) &&
-			(tx.ProcessingTypeOnSource == transactionProcessingTypeRelayed) &&
-			(tx.ProcessingTypeOnDestination == transactionProcessingTypeRelayed)
-
+		isRelayedTransaction := isRelayedV1Transaction(tx)
 		_, alreadyHeldInInvalidMiniblock := invalidTxs[tx.Hash]
 
 		if isRelayedTransaction && alreadyHeldInInvalidMiniblock {

--- a/server/services/transactionsFeaturesDetector.go
+++ b/server/services/transactionsFeaturesDetector.go
@@ -59,3 +59,18 @@ func (detector *transactionsFeaturesDetector) isInvalidTransactionOfTypeMoveBala
 	withMetaTransactionIsInvalid := detector.eventsController.hasSignalErrorOfMetaTransactionIsInvalid(tx)
 	return withSendingValueToNonPayableContract || withMetaTransactionIsInvalid
 }
+
+func (detector *transactionsFeaturesDetector) isRelayedTransactionCompletelyIntrashardWithSignalError(tx *transaction.ApiTransactionResult, innerTx *innerTransactionOfRelayedV1) bool {
+	innerTxSenderShard := detector.networkProvider.ComputeShardIdOfPubKey(innerTx.SenderPubKey)
+	innerTxReceiverShard := detector.networkProvider.ComputeShardIdOfPubKey(innerTx.ReceiverPubKey)
+
+	isCompletelyIntrashard := tx.SourceShard == tx.DestinationShard &&
+		innerTxSenderShard == innerTxReceiverShard &&
+		innerTxSenderShard == tx.SourceShard
+	if !isCompletelyIntrashard {
+		return false
+	}
+
+	isWithSignalError := detector.eventsController.hasAnySignalError(tx)
+	return isWithSignalError
+}

--- a/server/services/transactionsFeaturesDetector_test.go
+++ b/server/services/transactionsFeaturesDetector_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFeaturesDetector_IsInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(t *testing.T) {
+func TestTransactionsFeaturesDetector_IsInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()
 	detector := newTransactionsFeaturesDetector(networkProvider)
 
@@ -71,6 +72,68 @@ func TestFeaturesDetector_IsInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesD
 		}
 
 		featureDetected := detector.isInvalidTransactionOfTypeMoveBalanceThatOnlyConsumesDataMovementGas(tx)
+		require.True(t, featureDetected)
+	})
+}
+
+func TestTransactionsFeaturesDetector_IsRelayedTransactionCompletelyIntrashardWithSignalError(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	detector := newTransactionsFeaturesDetector(networkProvider)
+
+	pubkeyAShard0, _ := hex.DecodeString("8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8")
+	pubkeyBShard0, _ := hex.DecodeString("e32afedc904fe1939746ad973beb383563cf63642ba669b3040f9b9428a5ed60")
+	pubkeyShard1, _ := hex.DecodeString("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1")
+	pubkeyShard2, _ := hex.DecodeString("b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba")
+
+	t.Run("arbitrary relayed tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			SourceShard:      0,
+			DestinationShard: 1,
+		}
+
+		innerTx := &innerTransactionOfRelayedV1{
+			SenderPubKey:   pubkeyShard1,
+			ReceiverPubKey: pubkeyShard2,
+		}
+
+		featureDetected := detector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx)
+		require.False(t, featureDetected)
+	})
+
+	t.Run("completely intrashard relayed tx, but no signal error", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			SourceShard:      0,
+			DestinationShard: 0,
+		}
+
+		innerTx := &innerTransactionOfRelayedV1{
+			SenderPubKey:   pubkeyAShard0,
+			ReceiverPubKey: pubkeyBShard0,
+		}
+
+		featureDetected := detector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx)
+		require.False(t, featureDetected)
+	})
+
+	t.Run("completely intrashard relayed tx, with signal error", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			SourceShard:      0,
+			DestinationShard: 0,
+			Logs: &transaction.ApiLogs{
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+					},
+				},
+			},
+		}
+
+		innerTx := &innerTransactionOfRelayedV1{
+			SenderPubKey:   pubkeyAShard0,
+			ReceiverPubKey: pubkeyBShard0,
+		}
+
+		featureDetected := detector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx)
 		require.True(t, featureDetected)
 	})
 }

--- a/server/services/transactionsFeaturesDetector_test.go
+++ b/server/services/transactionsFeaturesDetector_test.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -80,11 +79,6 @@ func TestTransactionsFeaturesDetector_IsRelayedTransactionCompletelyIntrashardWi
 	networkProvider := testscommon.NewNetworkProviderMock()
 	detector := newTransactionsFeaturesDetector(networkProvider)
 
-	pubkeyAShard0, _ := hex.DecodeString("8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8")
-	pubkeyBShard0, _ := hex.DecodeString("e32afedc904fe1939746ad973beb383563cf63642ba669b3040f9b9428a5ed60")
-	pubkeyShard1, _ := hex.DecodeString("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1")
-	pubkeyShard2, _ := hex.DecodeString("b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba")
-
 	t.Run("arbitrary relayed tx", func(t *testing.T) {
 		tx := &transaction.ApiTransactionResult{
 			SourceShard:      0,
@@ -92,8 +86,8 @@ func TestTransactionsFeaturesDetector_IsRelayedTransactionCompletelyIntrashardWi
 		}
 
 		innerTx := &innerTransactionOfRelayedV1{
-			SenderPubKey:   pubkeyShard1,
-			ReceiverPubKey: pubkeyShard2,
+			SenderPubKey:   testscommon.TestUserShard1.PubKey,
+			ReceiverPubKey: testscommon.TestUserShard2.PubKey,
 		}
 
 		featureDetected := detector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx)
@@ -107,8 +101,8 @@ func TestTransactionsFeaturesDetector_IsRelayedTransactionCompletelyIntrashardWi
 		}
 
 		innerTx := &innerTransactionOfRelayedV1{
-			SenderPubKey:   pubkeyAShard0,
-			ReceiverPubKey: pubkeyBShard0,
+			SenderPubKey:   testscommon.TestUserAShard0.PubKey,
+			ReceiverPubKey: testscommon.TestUserBShard0.PubKey,
 		}
 
 		featureDetected := detector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx)
@@ -129,8 +123,8 @@ func TestTransactionsFeaturesDetector_IsRelayedTransactionCompletelyIntrashardWi
 		}
 
 		innerTx := &innerTransactionOfRelayedV1{
-			SenderPubKey:   pubkeyAShard0,
-			ReceiverPubKey: pubkeyBShard0,
+			SenderPubKey:   testscommon.TestUserAShard0.PubKey,
+			ReceiverPubKey: testscommon.TestUserBShard0.PubKey,
 		}
 
 		featureDetected := detector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx)

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -220,7 +220,7 @@ func (transformer *transactionsTransformer) extractInnerTxOperationsIfRelayedCom
 		return nil, err
 	}
 
-	if isZeroBigInt(&innerTx.Value) {
+	if isZeroBigIntOrNil(&innerTx.Value) {
 		return nil, nil
 	}
 

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -172,7 +172,7 @@ func (transformer *transactionsTransformer) rewardTxToRosettaTx(tx *transaction.
 }
 
 func (transformer *transactionsTransformer) normalTxToRosetta(tx *transaction.ApiTransactionResult) (*types.Transaction, error) {
-	hasValue := tx.Value != "0"
+	hasValue := !isZeroAmount(tx.Value)
 	operations := make([]*types.Operation, 0)
 
 	if hasValue {
@@ -218,6 +218,10 @@ func (transformer *transactionsTransformer) extractInnerTxOperationsIfRelayedCom
 	innerTx, err := parseInnerTxOfRelayedV1(tx)
 	if err != nil {
 		return nil, err
+	}
+
+	if isZeroBigInt(&innerTx.Value) {
+		return nil, nil
 	}
 
 	if !transformer.featuresDetector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx) {

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -212,20 +212,20 @@ func (transformer *transactionsTransformer) normalTxToRosetta(tx *transaction.Ap
 func (transformer *transactionsTransformer) extractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(tx *transaction.ApiTransactionResult) ([]*types.Operation, error) {
 	isRelayedTransaction := isRelayedV1Transaction(tx)
 	if !isRelayedTransaction {
-		return nil, nil
+		return []*types.Operation{}, nil
 	}
 
 	innerTx, err := parseInnerTxOfRelayedV1(tx)
 	if err != nil {
-		return nil, err
+		return []*types.Operation{}, err
 	}
 
 	if isZeroBigIntOrNil(&innerTx.Value) {
-		return nil, nil
+		return []*types.Operation{}, nil
 	}
 
 	if !transformer.featuresDetector.isRelayedTransactionCompletelyIntrashardWithSignalError(tx, innerTx) {
-		return nil, nil
+		return []*types.Operation{}, nil
 	}
 
 	senderAddress := transformer.provider.ConvertPubKeyToAddress(innerTx.SenderPubKey)

--- a/server/services/transactionsTransformer_test.go
+++ b/server/services/transactionsTransformer_test.go
@@ -60,9 +60,9 @@ func TestTransactionsTransformer_NormalTxToRosettaTx(t *testing.T) {
 			Receiver:                    testscommon.TestUserBShard0.Address,
 			SourceShard:                 0,
 			DestinationShard:            0,
-			Value:                       "1234",
 			InitiallyPaidFee:            "50000000000000",
-			Data:                        []byte("relayedTx@7b226e6f6e6365223a372c2273656e646572223a226e69424758747949504349644a78793373796c6c455a474c78506a503148734a45646e43732b6d726577413d222c227265636569766572223a224141414141414141414141464145356c3079623173734a3933504433672f4b396f48384579366d576958513d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a226e6830743338585a77614b6a725878446969716f6d364d6a5671724d612f6b70767474696a33692b5a6d43492f3778626830596762363548424151445744396f7036575567674541755430756e5253595736455341413d3d222c22636861696e4944223a224d513d3d222c2276657273696f6e223a327d"),
+			// Has non-zero value
+			Data: []byte("relayedTx@7b226e6f6e6365223a372c2273656e646572223a226e69424758747949504349644a78793373796c6c455a474c78506a503148734a45646e43732b6d726577413d222c227265636569766572223a224141414141414141414141464145356c3079623173734a3933504433672f4b396f48384579366d576958513d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a226e6830743338585a77614b6a725878446969716f6d364d6a5671724d612f6b70767474696a33692b5a6d43492f3778626830596762363548424151445744396f7036575567674541755430756e5253595736455341413d3d222c22636861696e4944223a224d513d3d222c2276657273696f6e223a327d"),
 			Logs: &transaction.ApiLogs{
 				Events: []*transaction.Events{
 					{
@@ -75,16 +75,6 @@ func TestTransactionsTransformer_NormalTxToRosettaTx(t *testing.T) {
 		expectedRosettaTx := &types.Transaction{
 			TransactionIdentifier: hashToTransactionIdentifier("aaaa"),
 			Operations: []*types.Operation{
-				{
-					Type:    opTransfer,
-					Account: addressToAccountIdentifier(testscommon.TestUserAShard0.Address),
-					Amount:  extension.valueToNativeAmount("-1234"),
-				},
-				{
-					Type:    opTransfer,
-					Account: addressToAccountIdentifier(testscommon.TestUserBShard0.Address),
-					Amount:  extension.valueToNativeAmount("1234"),
-				},
 				{
 					Type:    opFee,
 					Account: addressToAccountIdentifier(testscommon.TestUserAShard0.Address),
@@ -102,6 +92,85 @@ func TestTransactionsTransformer_NormalTxToRosettaTx(t *testing.T) {
 		rosettaTx, err := transformer.normalTxToRosetta(tx)
 		require.NoError(t, err)
 		require.Equal(t, expectedRosettaTx, rosettaTx)
+	})
+}
+
+func TestTransactionsTransformer_ExtractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	extension := newNetworkProviderExtension(networkProvider)
+	transformer := newTransactionsTransformer(networkProvider)
+
+	t.Run("non-relayed tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Type: string(transaction.TxTypeNormal),
+		}
+
+		operations, err := transformer.extractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(tx)
+		require.NoError(t, err)
+		require.Len(t, operations, 0)
+	})
+
+	t.Run("relayed tx (badly formatted)", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Type:                        string(transaction.TxTypeNormal),
+			ProcessingTypeOnSource:      transactionProcessingTypeRelayed,
+			ProcessingTypeOnDestination: transactionProcessingTypeRelayed,
+			Data:                        []byte("bad"),
+		}
+
+		operations, err := transformer.extractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(tx)
+		require.ErrorIs(t, err, errCannotParseRelayedV1)
+		require.Nil(t, operations)
+	})
+
+	t.Run("relayed tx, completely intrashard, with signal error, inner tx has non-zero value", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Type:                        string(transaction.TxTypeNormal),
+			ProcessingTypeOnSource:      transactionProcessingTypeRelayed,
+			ProcessingTypeOnDestination: transactionProcessingTypeRelayed,
+			SourceShard:                 0,
+			DestinationShard:            0,
+			Data:                        []byte("relayedTx@7b226e6f6e6365223a372c2273656e646572223a226e69424758747949504349644a78793373796c6c455a474c78506a503148734a45646e43732b6d726577413d222c227265636569766572223a224141414141414141414141464145356c3079623173734a3933504433672f4b396f48384579366d576958513d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a226e6830743338585a77614b6a725878446969716f6d364d6a5671724d612f6b70767474696a33692b5a6d43492f3778626830596762363548424151445744396f7036575567674541755430756e5253595736455341413d3d222c22636861696e4944223a224d513d3d222c2276657273696f6e223a327d"),
+			Logs: &transaction.ApiLogs{
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+					},
+				},
+			},
+		}
+
+		operations, err := transformer.extractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(tx)
+		require.NoError(t, err)
+		require.Equal(t, []*types.Operation{
+			{
+				Type:    opTransfer,
+				Account: addressToAccountIdentifier(testscommon.TestUserCShard0.Address),
+				Amount:  extension.valueToNativeAmount("-1000000000000000000"),
+			},
+		}, operations)
+	})
+
+	t.Run("relayed tx, completely intrashard, with signal error, inner tx has zero value", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Type:                        string(transaction.TxTypeNormal),
+			ProcessingTypeOnSource:      transactionProcessingTypeRelayed,
+			ProcessingTypeOnDestination: transactionProcessingTypeRelayed,
+			SourceShard:                 0,
+			DestinationShard:            0,
+			Data:                        []byte("relayedTx@7b226e6f6e6365223a372c2273656e646572223a226e69424758747949504349644a78793373796c6c455a474c78506a503148734a45646e43732b6d726577413d222c227265636569766572223a224141414141414141414141464145356c3079623173734a3933504433672f4b396f48384579366d576958513d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a22336c644e7a32435734416143675069495863636c466b4654324149586a4a4757316a526a306c542b4f3161736b6241394a744e365a764173396e394f58716d343130574a49665332332b4168666e48793267446c41773d3d222c22636861696e4944223a224d513d3d222c2276657273696f6e223a327d"),
+			Logs: &transaction.ApiLogs{
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+					},
+				},
+			},
+		}
+
+		operations, err := transformer.extractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(tx)
+		require.NoError(t, err)
+		require.Len(t, operations, 0)
 	})
 }
 

--- a/server/services/transactionsTransformer_test.go
+++ b/server/services/transactionsTransformer_test.go
@@ -9,7 +9,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO: Add more tests.
+func TestTransactionsTransformer_NormalTxToRosettaTx(t *testing.T) {
+	networkProvider := testscommon.NewNetworkProviderMock()
+	extension := newNetworkProviderExtension(networkProvider)
+	transformer := newTransactionsTransformer(networkProvider)
+
+	t.Run("move balance tx", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Hash:             "aaaa",
+			Sender:           testscommon.TestAddressAlice,
+			Receiver:         testscommon.TestAddressBob,
+			Value:            "1234",
+			InitiallyPaidFee: "50000000000000",
+		}
+
+		expectedRosettaTx := &types.Transaction{
+			TransactionIdentifier: hashToTransactionIdentifier("aaaa"),
+			Operations: []*types.Operation{
+				{
+					Type:    opTransfer,
+					Account: addressToAccountIdentifier(testscommon.TestAddressAlice),
+					Amount:  extension.valueToNativeAmount("-1234"),
+				},
+				{
+					Type:    opTransfer,
+					Account: addressToAccountIdentifier(testscommon.TestAddressBob),
+					Amount:  extension.valueToNativeAmount("1234"),
+				},
+				{
+					Type:    opFee,
+					Account: addressToAccountIdentifier(testscommon.TestAddressAlice),
+					Amount:  extension.valueToNativeAmount("-50000000000000"),
+				},
+			},
+			Metadata: extractTransactionMetadata(tx),
+		}
+
+		rosettaTx, err := transformer.normalTxToRosetta(tx)
+		require.NoError(t, err)
+		require.Equal(t, expectedRosettaTx, rosettaTx)
+	})
+
+	t.Run("relayed tx, completely intrashard, with signal error", func(t *testing.T) {
+		tx := &transaction.ApiTransactionResult{
+			Type:                        string(transaction.TxTypeNormal),
+			ProcessingTypeOnSource:      transactionProcessingTypeRelayed,
+			ProcessingTypeOnDestination: transactionProcessingTypeRelayed,
+			Hash:                        "aaaa",
+			Sender:                      testscommon.TestUserAShard0.Address,
+			Receiver:                    testscommon.TestUserBShard0.Address,
+			SourceShard:                 0,
+			DestinationShard:            0,
+			Value:                       "1234",
+			InitiallyPaidFee:            "50000000000000",
+			Data:                        []byte("relayedTx@7b226e6f6e6365223a372c2273656e646572223a226e69424758747949504349644a78793373796c6c455a474c78506a503148734a45646e43732b6d726577413d222c227265636569766572223a224141414141414141414141464145356c3079623173734a3933504433672f4b396f48384579366d576958513d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a226e6830743338585a77614b6a725878446969716f6d364d6a5671724d612f6b70767474696a33692b5a6d43492f3778626830596762363548424151445744396f7036575567674541755430756e5253595736455341413d3d222c22636861696e4944223a224d513d3d222c2276657273696f6e223a327d"),
+			Logs: &transaction.ApiLogs{
+				Events: []*transaction.Events{
+					{
+						Identifier: transactionEventSignalError,
+					},
+				},
+			},
+		}
+
+		expectedRosettaTx := &types.Transaction{
+			TransactionIdentifier: hashToTransactionIdentifier("aaaa"),
+			Operations: []*types.Operation{
+				{
+					Type:    opTransfer,
+					Account: addressToAccountIdentifier(testscommon.TestUserAShard0.Address),
+					Amount:  extension.valueToNativeAmount("-1234"),
+				},
+				{
+					Type:    opTransfer,
+					Account: addressToAccountIdentifier(testscommon.TestUserBShard0.Address),
+					Amount:  extension.valueToNativeAmount("1234"),
+				},
+				{
+					Type:    opFee,
+					Account: addressToAccountIdentifier(testscommon.TestUserAShard0.Address),
+					Amount:  extension.valueToNativeAmount("-50000000000000"),
+				},
+				{
+					Type:    opTransfer,
+					Account: addressToAccountIdentifier(testscommon.TestUserCShard0.Address),
+					Amount:  extension.valueToNativeAmount("-1000000000000000000"),
+				},
+			},
+			Metadata: extractTransactionMetadata(tx),
+		}
+
+		rosettaTx, err := transformer.normalTxToRosetta(tx)
+		require.NoError(t, err)
+		require.Equal(t, expectedRosettaTx, rosettaTx)
+	})
+}
 
 func TestTransactionsTransformer_UnsignedTxToRosettaTx(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()

--- a/server/services/transactionsTransformer_test.go
+++ b/server/services/transactionsTransformer_test.go
@@ -120,7 +120,7 @@ func TestTransactionsTransformer_ExtractInnerTxOperationsIfRelayedCompletelyIntr
 
 		operations, err := transformer.extractInnerTxOperationsIfRelayedCompletelyIntrashardWithSignalError(tx)
 		require.ErrorIs(t, err, errCannotParseRelayedV1)
-		require.Nil(t, operations)
+		require.Empty(t, operations)
 	})
 
 	t.Run("relayed tx, completely intrashard, with signal error, inner tx has non-zero value", func(t *testing.T) {

--- a/testscommon/addresses.go
+++ b/testscommon/addresses.go
@@ -8,6 +8,13 @@ var (
 
 	// TestAddressBob is a test address
 	TestAddressBob = "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
+	// TestPubKeyBob is a test pubkey
+	TestPubKeyBob, _ = RealWorldBech32PubkeyConverter.Decode(TestAddressBob)
+
+	// TestAddressCarol is a test address
+	TestAddressCarol = "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
+	// TestPubKeyCarol is a test pubkey
+	TestPubKeyCarol, _ = RealWorldBech32PubkeyConverter.Decode(TestAddressCarol)
 
 	// TestAddressOfContract is a test address
 	TestAddressOfContract = "erd1qqqqqqqqqqqqqpgqfejaxfh4ktp8mh8s77pl90dq0uzvh2vk396qlcwepw"

--- a/testscommon/addresses.go
+++ b/testscommon/addresses.go
@@ -1,21 +1,57 @@
 package testscommon
 
 var (
+	// TODO: use "testAccount", instead
 	// TestAddressAlice is a test address
 	TestAddressAlice = "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
 	// TestPubKeyAlice is a test pubkey
 	TestPubKeyAlice, _ = RealWorldBech32PubkeyConverter.Decode(TestAddressAlice)
 
+	// TODO: use "testAccount", instead
 	// TestAddressBob is a test address
 	TestAddressBob = "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
 	// TestPubKeyBob is a test pubkey
 	TestPubKeyBob, _ = RealWorldBech32PubkeyConverter.Decode(TestAddressBob)
 
+	// TODO: use "testAccount", instead
 	// TestAddressCarol is a test address
 	TestAddressCarol = "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
 	// TestPubKeyCarol is a test pubkey
 	TestPubKeyCarol, _ = RealWorldBech32PubkeyConverter.Decode(TestAddressCarol)
 
+	// TODO: use "testAccount", instead
 	// TestAddressOfContract is a test address
 	TestAddressOfContract = "erd1qqqqqqqqqqqqqpgqfejaxfh4ktp8mh8s77pl90dq0uzvh2vk396qlcwepw"
+
+	// TestUserAShard0 is a test account (user)
+	TestUserAShard0 = newTestAccount("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx")
+
+	// TestUserBShard0 is a test account (user)
+	TestUserBShard0 = newTestAccount("erd1uv40ahysflse896x4ktnh6ecx43u7cmy9wnxnvcyp7deg299a4sq6vaywa")
+
+	// TestUserCShard0 is a test account (user)
+	TestUserCShard0 = newTestAccount("erd1ncsyvhku3q7zy8f8rjmmx2t9zxgch38cel28kzg3m8pt86dt0vqqecw0gy")
+
+	// TestContractShard0 is a test account (contract)
+	TestContractShard0 = newTestAccount("erd1qqqqqqqqqqqqqpgqfejaxfh4ktp8mh8s77pl90dq0uzvh2vk396qlcwepw")
+
+	// TestUserShard1 is a test account (user)
+	TestUserShard1 = newTestAccount("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+
+	// TestUserShard2 is a test account (user)
+	TestUserShard2 = newTestAccount("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8")
 )
+
+type testAccount struct {
+	Address string
+	PubKey  []byte
+}
+
+func newTestAccount(address string) *testAccount {
+	pubKey, _ := RealWorldBech32PubkeyConverter.Decode(address)
+
+	return &testAccount{
+		Address: address,
+		PubKey:  pubKey,
+	}
+}

--- a/testscommon/networkProviderMock.go
+++ b/testscommon/networkProviderMock.go
@@ -244,18 +244,12 @@ func (mock *networkProviderMock) IsAddressObserved(address string) (bool, error)
 		return false, mock.MockNextError
 	}
 
-	shardCoordinator, err := sharding.NewMultiShardCoordinator(mock.MockNumShards, mock.MockObservedActualShard)
-	if err != nil {
-		return false, err
-	}
-
 	pubKey, err := mock.ConvertAddressToPubKey(address)
 	if err != nil {
 		return false, err
 	}
 
-	shard := shardCoordinator.ComputeId(pubKey)
-
+	shard := mock.ComputeShardIdOfPubKey(pubKey)
 	isObservedActualShard := shard == mock.MockObservedActualShard
 	isObservedProjectedShard := pubKey[len(pubKey)-1] == byte(mock.MockObservedProjectedShard)
 
@@ -264,6 +258,17 @@ func (mock *networkProviderMock) IsAddressObserved(address string) (bool, error)
 	}
 
 	return isObservedActualShard, nil
+}
+
+// ComputeShardIdOfPubKey -
+func (mock *networkProviderMock) ComputeShardIdOfPubKey(pubKey []byte) uint32 {
+	shardCoordinator, err := sharding.NewMultiShardCoordinator(mock.MockNumShards, mock.MockObservedActualShard)
+	if err != nil {
+		return 0
+	}
+
+	shard := shardCoordinator.ComputeId(pubKey)
+	return shard
 }
 
 // ConvertPubKeyToAddress -

--- a/testscommon/observerFacadeMock.go
+++ b/testscommon/observerFacadeMock.go
@@ -78,18 +78,14 @@ func (mock *observerFacadeMock) CallGetRestEndPoint(baseUrl string, path string,
 }
 
 // ComputeShardId -
-func (mock *observerFacadeMock) ComputeShardId(pubKey []byte) (uint32, error) {
-	if mock.MockNextError != nil {
-		return 0, mock.MockNextError
-	}
-
+func (mock *observerFacadeMock) ComputeShardId(pubKey []byte) uint32 {
 	shardCoordinator, err := sharding.NewMultiShardCoordinator(mock.MockNumShards, mock.MockSelfShard)
 	if err != nil {
-		return 0, err
+		return 0
 	}
 
 	shard := shardCoordinator.ComputeId(pubKey)
-	return shard, nil
+	return shard
 }
 
 // SendTransaction -

--- a/version/constants.go
+++ b/version/constants.go
@@ -7,5 +7,5 @@ const (
 
 var (
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.4.2"
+	RosettaMiddlewareVersion = "v0.4.4"
 )


### PR DESCRIPTION
While the balance changing operations are perfectly recoverable from most kinds of relayed transactions (given the smart contract results generated by the protocol), there is a case where this is only possible by also unwrapping and inspecting the _inner transaction_: when the relayed transaction is **completely intra-shard** (both the wrapping transaction and the inner transaction are intra-shard, in the same shard), and the processing of the transaction results into a **contract signal error**.

The PR handles this exotic case and emits an extra balance-changing operation.
