### PR TITLE
New CLI flag: --handle-contracts. Minor refactoring.

### DIFF
--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -156,9 +156,20 @@ VERSION:
 		Required: true,
 	}
 
+	cliFlagShouldHandleContracts = cli.BoolFlag{
+		Name:  "handle-contracts",
+		Usage: "Whether to handle balance changes of smart contracts or not.",
+	}
+
 	cliFlagConfigFileCustomCurrencies = cli.StringFlag{
 		Name:     "config-custom-currencies",
 		Usage:    "Specifies the configuration file for custom currencies.",
+		Required: false,
+	}
+
+	cliFlagConfigFileNodeFeatures = cli.StringFlag{
+		Name:     "config-node-features",
+		Usage:    "Specifies the configuration file for features activation on Node's side.",
 		Required: false,
 	}
 )
@@ -187,7 +198,9 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagNativeCurrencySymbol,
 		cliFlagFirstHistoricalEpoch,
 		cliFlagNumHistoricalEpochs,
+		cliFlagShouldHandleContracts,
 		cliFlagConfigFileCustomCurrencies,
+		cliFlagConfigFileNodeFeatures,
 	}
 }
 
@@ -215,7 +228,9 @@ type parsedCliFlags struct {
 	nativeCurrencySymbol        string
 	firstHistoricalEpoch        uint32
 	numHistoricalEpochs         uint32
+	shouldHandleContracts       bool
 	configFileCustomCurrencies  string
+	configFileNodeFeatures      string
 }
 
 func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
@@ -243,6 +258,8 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		nativeCurrencySymbol:        ctx.GlobalString(cliFlagNativeCurrencySymbol.Name),
 		firstHistoricalEpoch:        uint32(ctx.GlobalUint(cliFlagFirstHistoricalEpoch.Name)),
 		numHistoricalEpochs:         uint32(ctx.GlobalUint(cliFlagNumHistoricalEpochs.Name)),
+		shouldHandleContracts:       ctx.GlobalBool(cliFlagShouldHandleContracts.Name),
 		configFileCustomCurrencies:  ctx.GlobalString(cliFlagConfigFileCustomCurrencies.Name),
+		configFileNodeFeatures:      ctx.GlobalString(cliFlagConfigFileNodeFeatures.Name),
 	}
 }

--- a/cmd/rosetta/cli.go
+++ b/cmd/rosetta/cli.go
@@ -166,12 +166,6 @@ VERSION:
 		Usage:    "Specifies the configuration file for custom currencies.",
 		Required: false,
 	}
-
-	cliFlagConfigFileNodeFeatures = cli.StringFlag{
-		Name:     "config-node-features",
-		Usage:    "Specifies the configuration file for features activation on Node's side.",
-		Required: false,
-	}
 )
 
 func getAllCliFlags() []cli.Flag {
@@ -200,7 +194,6 @@ func getAllCliFlags() []cli.Flag {
 		cliFlagNumHistoricalEpochs,
 		cliFlagShouldHandleContracts,
 		cliFlagConfigFileCustomCurrencies,
-		cliFlagConfigFileNodeFeatures,
 	}
 }
 
@@ -230,7 +223,6 @@ type parsedCliFlags struct {
 	numHistoricalEpochs         uint32
 	shouldHandleContracts       bool
 	configFileCustomCurrencies  string
-	configFileNodeFeatures      string
 }
 
 func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
@@ -260,6 +252,5 @@ func getParsedCliFlags(ctx *cli.Context) parsedCliFlags {
 		numHistoricalEpochs:         uint32(ctx.GlobalUint(cliFlagNumHistoricalEpochs.Name)),
 		shouldHandleContracts:       ctx.GlobalBool(cliFlagShouldHandleContracts.Name),
 		configFileCustomCurrencies:  ctx.GlobalString(cliFlagConfigFileCustomCurrencies.Name),
-		configFileNodeFeatures:      ctx.GlobalString(cliFlagConfigFileNodeFeatures.Name),
 	}
 }

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -81,6 +81,7 @@ func startRosetta(ctx *cli.Context) error {
 		GenesisBlockHash:            cliFlags.genesisBlock,
 		FirstHistoricalEpoch:        cliFlags.firstHistoricalEpoch,
 		NumHistoricalEpochs:         cliFlags.numHistoricalEpochs,
+		ShouldHandleContracts:       cliFlags.shouldHandleContracts,
 	})
 	if err != nil {
 		return err

--- a/server/factory/provider.go
+++ b/server/factory/provider.go
@@ -48,6 +48,7 @@ type ArgsCreateNetworkProvider struct {
 	GenesisTimestamp            int64
 	FirstHistoricalEpoch        uint32
 	NumHistoricalEpochs         uint32
+	ShouldHandleContracts       bool
 }
 
 // CreateNetworkProvider creates a network provider
@@ -138,6 +139,7 @@ func CreateNetworkProvider(args ArgsCreateNetworkProvider) (NetworkProvider, err
 		GenesisTimestamp:            args.GenesisTimestamp,
 		FirstHistoricalEpoch:        args.FirstHistoricalEpoch,
 		NumHistoricalEpochs:         args.NumHistoricalEpochs,
+		ShouldHandleContracts:       args.ShouldHandleContracts,
 
 		ObserverFacade: &components.ObserverFacade{
 			Processor:            baseProcessor,

--- a/server/services/blockService.go
+++ b/server/services/blockService.go
@@ -145,7 +145,7 @@ func (service *blockService) createGenesisOperations(balances []*resources.Genes
 		operations = append(operations, operation)
 	}
 
-	operations, err := filterOperationsByAddress(operations, service.extension.isAddressObserved)
+	operations, err := filterOperationsByAddress(operations, service.provider.IsAddressObserved)
 	if err != nil {
 		return nil, err
 	}

--- a/server/services/networkProviderExtension.go
+++ b/server/services/networkProviderExtension.go
@@ -70,22 +70,16 @@ func (extension *networkProviderExtension) getGenesisBlockIdentifier() *types.Bl
 	return blockSummaryToIdentifier(summary)
 }
 
-func (extension *networkProviderExtension) isAddressObserved(address string) (bool, error) {
-	belongsToObservedShard, err := extension.provider.IsAddressObserved(address)
-	if err != nil {
-		return false, err
-	}
-
-	isUserAddress := extension.isUserAddress(address)
-	return belongsToObservedShard && isUserAddress, nil
-}
-
 func (extension *networkProviderExtension) isUserAddress(address string) bool {
-	pubkey, err := extension.provider.ConvertAddressToPubKey(address)
+	pubKey, err := extension.provider.ConvertAddressToPubKey(address)
 	if err != nil {
 		// E.g., when address = "metachain"
 		return false
 	}
 
-	return !core.IsSmartContractAddress(pubkey)
+	return extension.isUserPubKey(pubKey)
+}
+
+func (extension *networkProviderExtension) isUserPubKey(pubKey []byte) bool {
+	return !core.IsSmartContractAddress(pubKey)
 }

--- a/server/services/networkProviderExtension_test.go
+++ b/server/services/networkProviderExtension_test.go
@@ -40,22 +40,3 @@ func TestNetworkProviderExtension_ValueToCustomAmount(t *testing.T) {
 
 	require.Equal(t, expectedAmount, amount)
 }
-
-func TestNetworkProviderExtension_IsAddressObserved(t *testing.T) {
-	networkProvider := testscommon.NewNetworkProviderMock()
-	extension := newNetworkProviderExtension(networkProvider)
-
-	networkProvider.MockObservedActualShard = 0
-
-	isObserved, err := extension.isAddressObserved("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
-	require.NoError(t, err)
-	require.False(t, isObserved)
-
-	isObserved, err = extension.isAddressObserved("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx")
-	require.NoError(t, err)
-	require.True(t, isObserved)
-
-	isObserved, err = extension.isAddressObserved("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8")
-	require.NoError(t, err)
-	require.False(t, isObserved)
-}

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -66,7 +66,7 @@ func (transformer *transactionsTransformer) transformBlockTxs(block *api.Block) 
 	}
 
 	for _, rosettaTx := range rosettaTxs {
-		filteredOperations, err := filterOperationsByAddress(rosettaTx.Operations, transformer.extension.isAddressObserved)
+		filteredOperations, err := filterOperationsByAddress(rosettaTx.Operations, transformer.provider.IsAddressObserved)
 		if err != nil {
 			return nil, err
 		}

--- a/systemtests/proxyToObserverAdapter.go
+++ b/systemtests/proxyToObserverAdapter.go
@@ -57,7 +57,8 @@ func startAdapter(ctx *cli.Context) error {
 		sleepDuration: ctx.GlobalUint(cliFlagSleep.Name),
 	}
 
-	router := gin.Default()
+	router := gin.New()
+	router.Use(gin.Recovery())
 	router.GET("/node/status", adapter.getNodeStatus)
 	router.GET("/node/epoch-start/:epoch", adapter.getEpochStart)
 	router.GET("/block/by-nonce/:nonce", adapter.getBlockByNonce)


### PR DESCRIPTION
 - New CLI flag: `--handle-contracts` - whether to handle balance-changing operations for smart contracts, as well. By default, feature is disabled.
 - Refactor `IsAddressObserved()`.