### PR TITLE
Refactoring. NetworkProvider.GetAccountBalance() - a single method for getting balances

### DIFF
--- a/server/factory/interface.go
+++ b/server/factory/interface.go
@@ -25,8 +25,7 @@ type NetworkProvider interface {
 	GetBlockByNonce(nonce uint64) (*api.Block, error)
 	GetBlockByHash(hash string) (*api.Block, error)
 	GetAccount(address string) (*resources.AccountOnBlock, error)
-	GetAccountNativeBalance(address string, options resources.AccountQueryOptions) (*resources.AccountOnBlock, error)
-	GetAccountESDTBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) (*resources.AccountESDTBalance, error)
+	GetAccountBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) (*resources.AccountBalanceOnBlock, error)
 	IsAddressObserved(address string) (bool, error)
 	ComputeShardIdOfPubKey(pubkey []byte) uint32
 	ConvertPubKeyToAddress(pubkey []byte) string

--- a/server/provider/accounts.go
+++ b/server/provider/accounts.go
@@ -88,6 +88,7 @@ func (provider *networkProvider) getCustomTokenBalance(address string, tokenIden
 		"blockHash", data.BlockCoordinates.Hash,
 	)
 
+	// Here, we do not return the account nonce (not available without a second API call).
 	return &resources.AccountBalanceOnBlock{
 		Balance:          data.TokenData.Balance,
 		BlockCoordinates: data.BlockCoordinates,

--- a/server/provider/accounts_test.go
+++ b/server/provider/accounts_test.go
@@ -53,7 +53,7 @@ func TestNetworkProvider_GetAccount(t *testing.T) {
 	})
 }
 
-func TestNetworkProvider_GetAccountNativeBalance(t *testing.T) {
+func TestNetworkProvider_GetAccountBalance(t *testing.T) {
 	observerFacade := testscommon.NewObserverFacadeMock()
 	args := createDefaultArgsNewNetworkProvider()
 	args.ObserverFacade = observerFacade
@@ -64,7 +64,7 @@ func TestNetworkProvider_GetAccountNativeBalance(t *testing.T) {
 
 	optionsOnFinal := resources.NewAccountQueryOptionsOnFinalBlock()
 
-	t.Run("with success", func(t *testing.T) {
+	t.Run("native balance, with success", func(t *testing.T) {
 		observerFacade.MockNextError = nil
 		observerFacade.MockGetResponse = resources.AccountApiResponse{
 			Data: resources.AccountOnBlock{
@@ -77,38 +77,26 @@ func TestNetworkProvider_GetAccountNativeBalance(t *testing.T) {
 			},
 		}
 
-		accountBalance, err := provider.GetAccountNativeBalance(testscommon.TestAddressAlice, optionsOnFinal)
+		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "XeGLD", optionsOnFinal)
 		require.Nil(t, err)
-		require.Equal(t, "1", accountBalance.Account.Balance)
+		require.Equal(t, "1", accountBalance.Balance)
 		require.Equal(t, uint64(1000), accountBalance.BlockCoordinates.Nonce)
 		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
 		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th?onFinalBlock=true", observerFacade.RecordedPath)
 	})
 
-	t.Run("with error", func(t *testing.T) {
+	t.Run("native balance, with error", func(t *testing.T) {
 		observerFacade.MockNextError = errors.New("arbitrary error")
 		observerFacade.MockGetResponse = nil
 
-		accountBalance, err := provider.GetAccountNativeBalance(testscommon.TestAddressAlice, optionsOnFinal)
+		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "XeGLD", optionsOnFinal)
 		require.ErrorIs(t, err, errCannotGetAccount)
 		require.Nil(t, accountBalance)
 		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
 		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th?onFinalBlock=true", observerFacade.RecordedPath)
 	})
-}
 
-func TestNetworkProvider_GetAccountESDTBalance(t *testing.T) {
-	observerFacade := testscommon.NewObserverFacadeMock()
-	args := createDefaultArgsNewNetworkProvider()
-	args.ObserverFacade = observerFacade
-
-	provider, err := NewNetworkProvider(args)
-	require.Nil(t, err)
-	require.NotNil(t, provider)
-
-	optionsOnFinal := resources.NewAccountQueryOptionsOnFinalBlock()
-
-	t.Run("with success", func(t *testing.T) {
+	t.Run("fungible token, with success", func(t *testing.T) {
 		observerFacade.MockNextError = nil
 		observerFacade.MockGetResponse = resources.AccountESDTBalanceApiResponse{
 			Data: resources.AccountESDTBalanceApiResponsePayload{
@@ -121,7 +109,7 @@ func TestNetworkProvider_GetAccountESDTBalance(t *testing.T) {
 			},
 		}
 
-		accountBalance, err := provider.GetAccountESDTBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
+		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
 		require.Nil(t, err)
 		require.Equal(t, "1", accountBalance.Balance)
 		require.Equal(t, uint64(1000), accountBalance.BlockCoordinates.Nonce)
@@ -129,11 +117,11 @@ func TestNetworkProvider_GetAccountESDTBalance(t *testing.T) {
 		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef?onFinalBlock=true", observerFacade.RecordedPath)
 	})
 
-	t.Run("with error", func(t *testing.T) {
+	t.Run("fungible token, with error", func(t *testing.T) {
 		observerFacade.MockNextError = errors.New("arbitrary error")
 		observerFacade.MockGetResponse = nil
 
-		accountBalance, err := provider.GetAccountESDTBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
+		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
 		require.ErrorIs(t, err, errCannotGetAccount)
 		require.Nil(t, accountBalance)
 		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)

--- a/server/provider/accounts_test.go
+++ b/server/provider/accounts_test.go
@@ -70,6 +70,7 @@ func TestNetworkProvider_GetAccountBalance(t *testing.T) {
 			Data: resources.AccountOnBlock{
 				Account: resources.Account{
 					Balance: "1",
+					Nonce:   42,
 				},
 				BlockCoordinates: resources.BlockCoordinates{
 					Nonce: 1000,
@@ -80,6 +81,7 @@ func TestNetworkProvider_GetAccountBalance(t *testing.T) {
 		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "XeGLD", optionsOnFinal)
 		require.Nil(t, err)
 		require.Equal(t, "1", accountBalance.Balance)
+		require.Equal(t, uint64(42), accountBalance.Nonce.Value)
 		require.Equal(t, uint64(1000), accountBalance.BlockCoordinates.Nonce)
 		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
 		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th?onFinalBlock=true", observerFacade.RecordedPath)
@@ -112,6 +114,7 @@ func TestNetworkProvider_GetAccountBalance(t *testing.T) {
 		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
 		require.Nil(t, err)
 		require.Equal(t, "1", accountBalance.Balance)
+		require.False(t, accountBalance.Nonce.HasValue)
 		require.Equal(t, uint64(1000), accountBalance.BlockCoordinates.Nonce)
 		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
 		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef?onFinalBlock=true", observerFacade.RecordedPath)
@@ -126,5 +129,63 @@ func TestNetworkProvider_GetAccountBalance(t *testing.T) {
 		require.Nil(t, accountBalance)
 		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
 		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef?onFinalBlock=true", observerFacade.RecordedPath)
+	})
+
+	t.Run("non-fungible token, with success", func(t *testing.T) {
+		observerFacade.MockNextError = nil
+		observerFacade.MockGetResponse = resources.AccountESDTBalanceApiResponse{
+			Data: resources.AccountESDTBalanceApiResponsePayload{
+				TokenData: resources.AccountESDTTokenData{
+					Balance: "1",
+				},
+				BlockCoordinates: resources.BlockCoordinates{
+					Nonce: 1000,
+				},
+			},
+		}
+
+		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "ABC-abcdef-0a", optionsOnFinal)
+		require.Nil(t, err)
+		require.Equal(t, "1", accountBalance.Balance)
+		require.False(t, accountBalance.Nonce.HasValue)
+		require.Equal(t, uint64(1000), accountBalance.BlockCoordinates.Nonce)
+		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
+		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/nft/ABC-abcdef/nonce/10?onFinalBlock=true", observerFacade.RecordedPath)
+	})
+
+	t.Run("non-fungible token, with error", func(t *testing.T) {
+		observerFacade.MockNextError = errors.New("arbitrary error")
+		observerFacade.MockGetResponse = nil
+
+		accountBalance, err := provider.GetAccountBalance(testscommon.TestAddressAlice, "ABC-abcdef-0a", optionsOnFinal)
+		require.ErrorIs(t, err, errCannotGetAccount)
+		require.Nil(t, accountBalance)
+		require.Equal(t, args.ObserverUrl, observerFacade.RecordedBaseUrl)
+		require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/nft/ABC-abcdef/nonce/10?onFinalBlock=true", observerFacade.RecordedPath)
+	})
+}
+
+func TestDecideCustomTokenBalanceUrl(t *testing.T) {
+	args := createDefaultArgsNewNetworkProvider()
+	provider, err := NewNetworkProvider(args)
+	require.Nil(t, err)
+	require.NotNil(t, provider)
+
+	t.Run("for fungible", func(t *testing.T) {
+		url, err := decideCustomTokenBalanceUrl(testscommon.TestAddressCarol, "ABC-abcdef", resources.AccountQueryOptions{})
+		require.Nil(t, err)
+		require.Equal(t, "/address/erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8/esdt/ABC-abcdef", url)
+	})
+
+	t.Run("for non-fungible", func(t *testing.T) {
+		url, err := decideCustomTokenBalanceUrl(testscommon.TestAddressCarol, "ABC-abcdef-0a", resources.AccountQueryOptions{})
+		require.Nil(t, err)
+		require.Equal(t, "/address/erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8/nft/ABC-abcdef/nonce/10", url)
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		url, err := decideCustomTokenBalanceUrl(testscommon.TestAddressCarol, "ABC", resources.AccountQueryOptions{})
+		require.ErrorIs(t, err, errCannotParseTokenIdentifier)
+		require.Empty(t, url)
 	})
 }

--- a/server/provider/errors.go
+++ b/server/provider/errors.go
@@ -12,6 +12,7 @@ var errCannotGetAccount = errors.New("cannot get account")
 var errCannotGetTransaction = errors.New("cannot get transaction")
 var errCannotGetLatestBlockNonce = errors.New("cannot get latest block nonce, maybe the node didn't start syncing")
 var errInvalidCustomCurrencySymbol = errors.New("invalid custom currency symbol")
+var errCannotParseTokenIdentifier = errors.New("cannot parse token identifier")
 
 func newErrCannotGetBlockByNonce(nonce uint64, innerError error) error {
 	return fmt.Errorf("%w: %v, nonce = %d", errCannotGetBlock, innerError, nonce)
@@ -31,6 +32,10 @@ func newErrCannotGetTransaction(hash string, innerError error) error {
 
 func newInvalidCustomCurrency(index int) error {
 	return fmt.Errorf("%w, index = %d", errInvalidCustomCurrencySymbol, index)
+}
+
+func newErrCannotParseTokenIdentifier(tokenIdentifier string, innerError error) error {
+	return fmt.Errorf("%w: %v, tokenIdentifier = %s", errCannotParseTokenIdentifier, innerError, tokenIdentifier)
 }
 
 // In proxy-go, the function CallGetRestEndPoint() returns an error message as the JSON content of the erroneous HTTP response.

--- a/server/provider/tokenIdentifierParts.go
+++ b/server/provider/tokenIdentifierParts.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type tokenIdentifierParts struct {
+	ticker                   string
+	randomSequence           string
+	tickerWithRandomSequence string
+	nonce                    uint64
+}
+
+func parseTokenIdentifierIntoParts(tokenIdentifier string) (*tokenIdentifierParts, error) {
+	parts := strings.Split(tokenIdentifier, "-")
+
+	// Fungible tokens
+	if len(parts) == 2 {
+		return &tokenIdentifierParts{
+			ticker:                   parts[0],
+			randomSequence:           parts[1],
+			tickerWithRandomSequence: tokenIdentifier,
+			nonce:                    0,
+		}, nil
+	}
+
+	// Non-fungible tokens
+	if len(parts) == 3 {
+		nonceHex := parts[2]
+		nonce, err := strconv.ParseUint(nonceHex, 16, 64)
+		if err != nil {
+			return nil, newErrCannotParseTokenIdentifier(tokenIdentifier, err)
+		}
+
+		return &tokenIdentifierParts{
+			ticker:                   parts[0],
+			randomSequence:           parts[1],
+			tickerWithRandomSequence: fmt.Sprintf("%s-%s", parts[0], parts[1]),
+			nonce:                    nonce,
+		}, nil
+	}
+
+	return nil, newErrCannotParseTokenIdentifier(tokenIdentifier, nil)
+}

--- a/server/provider/tokenIdentifierParts_test.go
+++ b/server/provider/tokenIdentifierParts_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTokenIdentifierIntoParts(t *testing.T) {
+	t.Run("with fungible token", func(t *testing.T) {
+		parts, err := parseTokenIdentifierIntoParts("ROSETTA-2c0a37")
+		require.Nil(t, err)
+		require.NotNil(t, parts)
+		require.Equal(t, "ROSETTA", parts.ticker)
+		require.Equal(t, "2c0a37", parts.randomSequence)
+		require.Equal(t, "ROSETTA-2c0a37", parts.tickerWithRandomSequence)
+		require.Equal(t, uint64(0), parts.nonce)
+	})
+
+	t.Run("with non-fungible token", func(t *testing.T) {
+		parts, err := parseTokenIdentifierIntoParts("EXAMPLE-453bec-0a")
+		require.Nil(t, err)
+		require.NotNil(t, parts)
+		require.Equal(t, "EXAMPLE", parts.ticker)
+		require.Equal(t, "453bec", parts.randomSequence)
+		require.Equal(t, "EXAMPLE-453bec", parts.tickerWithRandomSequence)
+		require.Equal(t, uint64(10), parts.nonce)
+	})
+
+	t.Run("with invalid custom token identifier", func(t *testing.T) {
+		parts, err := parseTokenIdentifierIntoParts("token")
+		require.ErrorIs(t, err, errCannotParseTokenIdentifier)
+		require.Nil(t, parts)
+	})
+}

--- a/server/provider/urls.go
+++ b/server/provider/urls.go
@@ -15,7 +15,8 @@ var (
 	urlPathGetGenesisBalances                   = "/network/genesis-balances"
 	urlPathGetAccount                           = "/address/%s"
 	urlPathGetAccountNativeBalance              = "/address/%s"
-	urlPathGetAccountESDTBalance                = "/address/%s/esdt/%s"
+	urlPathGetAccountFungibleTokenBalance       = "/address/%s/esdt/%s"
+	urlPathGetAccountNonFungibleTokenBalance    = "/address/%s/nft/%s/nonce/%d"
 	urlParameterAccountQueryOptionsOnFinalBlock = "onFinalBlock"
 	urlParameterAccountQueryOptionsBlockNonce   = "blockNonce"
 	urlParameterAccountQueryOptionsBlockHash    = "blockHash"
@@ -34,8 +35,12 @@ func buildUrlGetAccountNativeBalance(address string, options resources.AccountQu
 	return buildUrlWithAccountQueryOptions(fmt.Sprintf(urlPathGetAccountNativeBalance, address), options)
 }
 
-func buildUrlGetAccountESDTBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) string {
-	return buildUrlWithAccountQueryOptions(fmt.Sprintf(urlPathGetAccountESDTBalance, address, tokenIdentifier), options)
+func buildUrlGetAccountFungibleTokenBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) string {
+	return buildUrlWithAccountQueryOptions(fmt.Sprintf(urlPathGetAccountFungibleTokenBalance, address, tokenIdentifier), options)
+}
+
+func buildUrlGetAccountNonFungibleTokenBalance(address string, tokenIdentifier string, nonce uint64, options resources.AccountQueryOptions) string {
+	return buildUrlWithAccountQueryOptions(fmt.Sprintf(urlPathGetAccountNonFungibleTokenBalance, address, tokenIdentifier, nonce), options)
 }
 
 func buildUrlWithAccountQueryOptions(path string, options resources.AccountQueryOptions) string {

--- a/server/provider/urls_test.go
+++ b/server/provider/urls_test.go
@@ -36,15 +36,15 @@ func TestBuildUrlGetAccountESDTBalance(t *testing.T) {
 	optionsAtBlockNonce := resources.NewAccountQueryOptionsWithBlockNonce(7)
 	optionsAtBlockHash := resources.NewAccountQueryOptionsWithBlockHash([]byte{0xaa, 0xbb, 0xcc, 0xdd})
 
-	url := buildUrlGetAccountESDTBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
+	url := buildUrlGetAccountFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsOnFinal)
 	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef?onFinalBlock=true", url)
 
-	url = buildUrlGetAccountESDTBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsAtBlockNonce)
+	url = buildUrlGetAccountFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsAtBlockNonce)
 	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef?blockNonce=7", url)
 
-	url = buildUrlGetAccountESDTBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsAtBlockHash)
+	url = buildUrlGetAccountFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", optionsAtBlockHash)
 	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef?blockHash=aabbccdd", url)
 
-	url = buildUrlGetAccountESDTBalance(testscommon.TestAddressAlice, "ABC-abcdef", resources.AccountQueryOptions{})
+	url = buildUrlGetAccountFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", resources.AccountQueryOptions{})
 	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef", url)
 }

--- a/server/provider/urls_test.go
+++ b/server/provider/urls_test.go
@@ -31,7 +31,7 @@ func TestBuildUrlGetAccountNativeBalance(t *testing.T) {
 	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th", url)
 }
 
-func TestBuildUrlGetAccountESDTBalance(t *testing.T) {
+func TestBuildUrlGetAccountFungibleTokenBalance(t *testing.T) {
 	optionsOnFinal := resources.NewAccountQueryOptionsOnFinalBlock()
 	optionsAtBlockNonce := resources.NewAccountQueryOptionsWithBlockNonce(7)
 	optionsAtBlockHash := resources.NewAccountQueryOptionsWithBlockHash([]byte{0xaa, 0xbb, 0xcc, 0xdd})
@@ -47,4 +47,22 @@ func TestBuildUrlGetAccountESDTBalance(t *testing.T) {
 
 	url = buildUrlGetAccountFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", resources.AccountQueryOptions{})
 	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/esdt/ABC-abcdef", url)
+}
+
+func TestBuildUrlGetAccountNonFungibleTokenBalance(t *testing.T) {
+	optionsOnFinal := resources.NewAccountQueryOptionsOnFinalBlock()
+	optionsAtBlockNonce := resources.NewAccountQueryOptionsWithBlockNonce(7)
+	optionsAtBlockHash := resources.NewAccountQueryOptionsWithBlockHash([]byte{0xaa, 0xbb, 0xcc, 0xdd})
+
+	url := buildUrlGetAccountNonFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", 10, optionsOnFinal)
+	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/nft/ABC-abcdef/nonce/10?onFinalBlock=true", url)
+
+	url = buildUrlGetAccountNonFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", 10, optionsAtBlockNonce)
+	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/nft/ABC-abcdef/nonce/10?blockNonce=7", url)
+
+	url = buildUrlGetAccountNonFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", 10, optionsAtBlockHash)
+	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/nft/ABC-abcdef/nonce/10?blockHash=aabbccdd", url)
+
+	url = buildUrlGetAccountNonFungibleTokenBalance(testscommon.TestAddressAlice, "ABC-abcdef", 10, resources.AccountQueryOptions{})
+	require.Equal(t, "/address/erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th/nft/ABC-abcdef/nonce/10", url)
 }

--- a/server/resources/accounts.go
+++ b/server/resources/accounts.go
@@ -1,6 +1,10 @@
 package resources
 
-// AccountApiResponse defines an account resource
+import (
+	"github.com/multiversx/mx-chain-core-go/core"
+)
+
+// AccountApiResponse is an API resource
 type AccountApiResponse struct {
 	resourceApiResponse
 	Data AccountOnBlock `json:"data"`
@@ -14,13 +18,12 @@ type AccountOnBlock struct {
 
 // Account defines an account resource
 type Account struct {
-	Address  string `json:"address"`
-	Nonce    uint64 `json:"nonce"`
-	Balance  string `json:"balance"`
-	Username string `json:"username"`
+	Address string `json:"address"`
+	Nonce   uint64 `json:"nonce"`
+	Balance string `json:"balance"`
 }
 
-// AccountESDTBalanceApiResponse defines an account resource
+// AccountESDTBalanceApiResponse is an API resource
 type AccountESDTBalanceApiResponse struct {
 	resourceApiResponse
 	Data AccountESDTBalanceApiResponsePayload `json:"data"`
@@ -32,15 +35,15 @@ type AccountESDTBalanceApiResponsePayload struct {
 	BlockCoordinates BlockCoordinates     `json:"blockInfo"`
 }
 
-// AccountESDTTokenData defines an account resource
+// AccountESDTTokenData is an API resource
 type AccountESDTTokenData struct {
 	Identifier string `json:"tokenIdentifier"`
 	Balance    string `json:"balance"`
-	Properties string `json:"properties"`
 }
 
-// AccountESDTBalance defines an account resource
-type AccountESDTBalance struct {
+// AccountBalanceOnBlock defines an account resource
+type AccountBalanceOnBlock struct {
 	Balance          string
+	Nonce            core.OptionalUint64
 	BlockCoordinates BlockCoordinates
 }

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -28,7 +28,6 @@ type Currency struct {
 
 // BlockCoordinates is an API resource
 type BlockCoordinates struct {
-	Nonce    uint64 `json:"nonce"`
-	Hash     string `json:"hash"`
-	RootHash string `json:"rootHash"`
+	Nonce uint64 `json:"nonce"`
+	Hash  string `json:"hash"`
 }

--- a/server/services/accountService_test.go
+++ b/server/services/accountService_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-rosetta/server/resources"
 	"github.com/multiversx/mx-chain-rosetta/testscommon"
 	"github.com/stretchr/testify/require"
@@ -38,8 +39,8 @@ func TestAccountService_AccountBalance(t *testing.T) {
 			AccountIdentifier: &types.AccountIdentifier{Address: "alice"},
 		}
 
-		networkProvider.MockAccountsNativeBalances["alice"] = &resources.Account{
-			Nonce:   7,
+		networkProvider.MockAccountsNativeBalances["alice"] = &resources.AccountBalanceOnBlock{
+			Nonce:   core.OptionalUint64{Value: 7, HasValue: true},
 			Balance: "100",
 		}
 		networkProvider.MockNextAccountBlockCoordinates.Nonce = 42
@@ -64,8 +65,8 @@ func TestAccountService_AccountBalance(t *testing.T) {
 			},
 		}
 
-		networkProvider.MockAccountsNativeBalances["alice"] = &resources.Account{
-			Nonce:   7,
+		networkProvider.MockAccountsNativeBalances["alice"] = &resources.AccountBalanceOnBlock{
+			Nonce:   core.OptionalUint64{Value: 7, HasValue: true},
 			Balance: "1000",
 		}
 		networkProvider.MockNextAccountBlockCoordinates.Nonce = 42
@@ -89,7 +90,7 @@ func TestAccountService_AccountBalance(t *testing.T) {
 			},
 		}
 
-		networkProvider.MockAccountsESDTBalances["alice_FOO-abcdef"] = &resources.AccountESDTBalance{
+		networkProvider.MockAccountsCustomBalances["alice_FOO-abcdef"] = &resources.AccountBalanceOnBlock{
 			Balance: "500",
 		}
 		networkProvider.MockNextAccountBlockCoordinates.Nonce = 42
@@ -116,10 +117,10 @@ func TestAccountService_AccountBalance(t *testing.T) {
 			},
 		}
 
-		networkProvider.MockAccountsESDTBalances["alice_FOO-abcdef"] = &resources.AccountESDTBalance{
+		networkProvider.MockAccountsCustomBalances["alice_FOO-abcdef"] = &resources.AccountBalanceOnBlock{
 			Balance: "500",
 		}
-		networkProvider.MockAccountsESDTBalances["alice_BAR-abcdef"] = &resources.AccountESDTBalance{
+		networkProvider.MockAccountsCustomBalances["alice_BAR-abcdef"] = &resources.AccountBalanceOnBlock{
 			Balance: "700",
 		}
 		networkProvider.MockNextAccountBlockCoordinates.Nonce = 42

--- a/server/services/interface.go
+++ b/server/services/interface.go
@@ -24,8 +24,7 @@ type NetworkProvider interface {
 	GetBlockByNonce(nonce uint64) (*api.Block, error)
 	GetBlockByHash(hash string) (*api.Block, error)
 	GetAccount(address string) (*resources.AccountOnBlock, error)
-	GetAccountNativeBalance(address string, options resources.AccountQueryOptions) (*resources.AccountOnBlock, error)
-	GetAccountESDTBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) (*resources.AccountESDTBalance, error)
+	GetAccountBalance(address string, tokenIdentifier string, options resources.AccountQueryOptions) (*resources.AccountBalanceOnBlock, error)
 	IsAddressObserved(address string) (bool, error)
 	ComputeShardIdOfPubKey(pubkey []byte) uint32
 	ConvertPubKeyToAddress(pubkey []byte) string

--- a/server/services/networkProviderExtension.go
+++ b/server/services/networkProviderExtension.go
@@ -16,6 +16,14 @@ func newNetworkProviderExtension(provider NetworkProvider) *networkProviderExten
 	}
 }
 
+func (extension *networkProviderExtension) valueToAmount(value string, currencySymbol string) *types.Amount {
+	if extension.isNativeCurrencySymbol(currencySymbol) {
+		return extension.valueToNativeAmount(value)
+	}
+
+	return extension.valueToCustomAmount(value, currencySymbol)
+}
+
 func (extension *networkProviderExtension) valueToNativeAmount(value string) *types.Amount {
 	return &types.Amount{
 		Value:    value,

--- a/server/services/networkProviderExtension_test.go
+++ b/server/services/networkProviderExtension_test.go
@@ -4,39 +4,72 @@ import (
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/multiversx/mx-chain-rosetta/server/resources"
 	"github.com/multiversx/mx-chain-rosetta/testscommon"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNetworkProviderExtension_ValueToNativeAmount(t *testing.T) {
+func TestNetworkProviderExtension_ValueToAmount(t *testing.T) {
 	networkProvider := testscommon.NewNetworkProviderMock()
 	networkProvider.MockNativeCurrencySymbol = "EGLD"
-	extension := newNetworkProviderExtension(networkProvider)
-
-	amount := extension.valueToNativeAmount("1")
-	expectedAmount := &types.Amount{
-		Value: "1",
-		Currency: &types.Currency{
-			Symbol:   "EGLD",
-			Decimals: 18,
-		},
-	}
-
-	require.Equal(t, expectedAmount, amount)
-}
-
-func TestNetworkProviderExtension_ValueToCustomAmount(t *testing.T) {
-	networkProvider := testscommon.NewNetworkProviderMock()
-	extension := newNetworkProviderExtension(networkProvider)
-
-	amount := extension.valueToCustomAmount("1", "ABC-abcdef")
-	expectedAmount := &types.Amount{
-		Value: "1",
-		Currency: &types.Currency{
+	networkProvider.MockCustomCurrencies = []resources.Currency{
+		{
 			Symbol:   "ABC-abcdef",
-			Decimals: 0,
+			Decimals: 4,
 		},
 	}
 
-	require.Equal(t, expectedAmount, amount)
+	extension := newNetworkProviderExtension(networkProvider)
+
+	t.Run("with native currency", func(t *testing.T) {
+		amount := extension.valueToAmount("1", "EGLD")
+		expectedAmount := &types.Amount{
+			Value: "1",
+			Currency: &types.Currency{
+				Symbol:   "EGLD",
+				Decimals: 18,
+			},
+		}
+
+		require.Equal(t, expectedAmount, amount)
+	})
+
+	t.Run("with native currency (explicitly)", func(t *testing.T) {
+		amount := extension.valueToNativeAmount("1")
+		expectedAmount := &types.Amount{
+			Value: "1",
+			Currency: &types.Currency{
+				Symbol:   "EGLD",
+				Decimals: 18,
+			},
+		}
+
+		require.Equal(t, expectedAmount, amount)
+	})
+
+	t.Run("with custom currency", func(t *testing.T) {
+		amount := extension.valueToAmount("1", "ABC-abcdef")
+		expectedAmount := &types.Amount{
+			Value: "1",
+			Currency: &types.Currency{
+				Symbol:   "ABC-abcdef",
+				Decimals: 4,
+			},
+		}
+
+		require.Equal(t, expectedAmount, amount)
+	})
+
+	t.Run("with custom currency (explicitly)", func(t *testing.T) {
+		amount := extension.valueToCustomAmount("1", "ABC-abcdef")
+		expectedAmount := &types.Amount{
+			Value: "1",
+			Currency: &types.Currency{
+				Symbol:   "ABC-abcdef",
+				Decimals: 4,
+			},
+		}
+
+		require.Equal(t, expectedAmount, amount)
+	})
 }

--- a/server/services/transactionEvents.go
+++ b/server/services/transactionEvents.go
@@ -18,8 +18,8 @@ func (event *eventESDT) getBaseIdentifier() string {
 	return event.identifier
 }
 
-// getComposedIdentifier returns the "full" token identifier for all types of ESDTs
-func (event *eventESDT) getComposedIdentifier() string {
+// getExtendedIdentifier returns the "full" token identifier for all types of ESDTs
+func (event *eventESDT) getExtendedIdentifier() string {
 	if len(event.nonceAsBytes) > 0 {
 		return fmt.Sprintf("%s-%x", event.identifier, event.nonceAsBytes)
 	}

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -65,7 +65,7 @@ func (controller *transactionEventsController) extractEventsESDTOrESDTNFTTransfe
 			return nil, fmt.Errorf("%w: bad number of topics for (ESDT|ESDTNFT)Transfer event = %d", errCannotRecognizeEvent, numTopics)
 		}
 
-		identifider := event.Topics[0]
+		identifier := event.Topics[0]
 		nonceAsBytes := event.Topics[1]
 		valueBytes := event.Topics[2]
 		receiverPubkey := event.Topics[3]
@@ -76,7 +76,7 @@ func (controller *transactionEventsController) extractEventsESDTOrESDTNFTTransfe
 		typedEvents = append(typedEvents, &eventESDT{
 			senderAddress:   event.Address,
 			receiverAddress: receiver,
-			identifier:      string(identifider),
+			identifier:      string(identifier),
 			nonceAsBytes:    nonceAsBytes,
 			value:           value.String(),
 		})
@@ -125,14 +125,14 @@ func (controller *transactionEventsController) extractEventsESDTLocalBurn(tx *tr
 			return nil, fmt.Errorf("%w: bad number of topics for ESDTLocalBurn event = %d", errCannotRecognizeEvent, numTopics)
 		}
 
-		identifider := event.Topics[0]
+		identifier := event.Topics[0]
 		nonceAsBytes := event.Topics[1]
 		valueBytes := event.Topics[2]
 		value := big.NewInt(0).SetBytes(valueBytes)
 
 		typedEvents = append(typedEvents, &eventESDT{
 			otherAddress: event.Address,
-			identifier:   string(identifider),
+			identifier:   string(identifier),
 			nonceAsBytes: nonceAsBytes,
 			value:        value.String(),
 		})
@@ -151,14 +151,14 @@ func (controller *transactionEventsController) extractEventsESDTLocalMint(tx *tr
 			return nil, fmt.Errorf("%w: bad number of topics for ESDTLocalMint event = %d", errCannotRecognizeEvent, numTopics)
 		}
 
-		identifider := event.Topics[0]
+		identifier := event.Topics[0]
 		nonceAsBytes := event.Topics[1]
 		valueBytes := event.Topics[2]
 		value := big.NewInt(0).SetBytes(valueBytes)
 
 		typedEvents = append(typedEvents, &eventESDT{
 			otherAddress: event.Address,
-			identifier:   string(identifider),
+			identifier:   string(identifier),
 			nonceAsBytes: nonceAsBytes,
 			value:        value.String(),
 		})
@@ -177,7 +177,7 @@ func (controller *transactionEventsController) extractEventsESDTWipe(tx *transac
 			return nil, fmt.Errorf("%w: bad number of topics for ESDTWipe event = %d", errCannotRecognizeEvent, numTopics)
 		}
 
-		identifider := event.Topics[0]
+		identifier := event.Topics[0]
 		nonceAsBytes := event.Topics[1]
 		valueBytes := event.Topics[2]
 		accountPubkey := event.Topics[3]
@@ -187,7 +187,7 @@ func (controller *transactionEventsController) extractEventsESDTWipe(tx *transac
 
 		typedEvents = append(typedEvents, &eventESDT{
 			otherAddress: accountAddress,
-			identifier:   string(identifider),
+			identifier:   string(identifier),
 			nonceAsBytes: nonceAsBytes,
 			value:        value.String(),
 		})

--- a/server/services/transactionEvents_test.go
+++ b/server/services/transactionEvents_test.go
@@ -16,7 +16,7 @@ func TestEventESDT(t *testing.T) {
 		}
 
 		require.Equal(t, "FOO-abcdef", event.getBaseIdentifier())
-		require.Equal(t, "FOO-abcdef", event.getComposedIdentifier())
+		require.Equal(t, "FOO-abcdef", event.getExtendedIdentifier())
 
 		event = eventESDT{
 			identifier:   "FOO-abcdef",
@@ -24,7 +24,7 @@ func TestEventESDT(t *testing.T) {
 		}
 
 		require.Equal(t, "FOO-abcdef", event.getBaseIdentifier())
-		require.Equal(t, "FOO-abcdef", event.getComposedIdentifier())
+		require.Equal(t, "FOO-abcdef", event.getExtendedIdentifier())
 	})
 
 	t.Run("with nonce (SFT, MetaESDT, NFT)", func(t *testing.T) {
@@ -34,7 +34,7 @@ func TestEventESDT(t *testing.T) {
 		}
 
 		require.Equal(t, "FOO-abcdef", event.getBaseIdentifier())
-		require.Equal(t, "FOO-abcdef-2a", event.getComposedIdentifier())
+		require.Equal(t, "FOO-abcdef-2a", event.getExtendedIdentifier())
 	})
 }
 

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -353,12 +353,12 @@ func (transformer *transactionsTransformer) addOperationsGivenTransactionEvents(
 			{
 				Type:    opCustomTransfer,
 				Account: addressToAccountIdentifier(event.senderAddress),
-				Amount:  transformer.extension.valueToCustomAmount("-"+event.value, event.getComposedIdentifier()),
+				Amount:  transformer.extension.valueToCustomAmount("-"+event.value, event.getExtendedIdentifier()),
 			},
 			{
 				Type:    opCustomTransfer,
 				Account: addressToAccountIdentifier(event.receiverAddress),
-				Amount:  transformer.extension.valueToCustomAmount(event.value, event.getComposedIdentifier()),
+				Amount:  transformer.extension.valueToCustomAmount(event.value, event.getExtendedIdentifier()),
 			},
 		}
 
@@ -375,7 +375,7 @@ func (transformer *transactionsTransformer) addOperationsGivenTransactionEvents(
 			{
 				Type:    opCustomTransfer,
 				Account: addressToAccountIdentifier(event.otherAddress),
-				Amount:  transformer.extension.valueToCustomAmount("-"+event.value, event.getComposedIdentifier()),
+				Amount:  transformer.extension.valueToCustomAmount("-"+event.value, event.getExtendedIdentifier()),
 			},
 		}
 
@@ -392,7 +392,7 @@ func (transformer *transactionsTransformer) addOperationsGivenTransactionEvents(
 			{
 				Type:    opCustomTransfer,
 				Account: addressToAccountIdentifier(event.otherAddress),
-				Amount:  transformer.extension.valueToCustomAmount(event.value, event.getComposedIdentifier()),
+				Amount:  transformer.extension.valueToCustomAmount(event.value, event.getExtendedIdentifier()),
 			},
 		}
 
@@ -409,7 +409,7 @@ func (transformer *transactionsTransformer) addOperationsGivenTransactionEvents(
 			{
 				Type:    opCustomTransfer,
 				Account: addressToAccountIdentifier(event.otherAddress),
-				Amount:  transformer.extension.valueToCustomAmount("-"+event.value, event.getComposedIdentifier()),
+				Amount:  transformer.extension.valueToCustomAmount("-"+event.value, event.getExtendedIdentifier()),
 			},
 		}
 


### PR DESCRIPTION
 - `NetworkProvider.GetAccountBalance()` -  a single method for getting balances (whether for the native currency or for custom ones).
 - Handle non-fungible tokens in `GetAccountBalance()`, as well.
 - Additional minor refactoring, plus unit tests
 - System tests for NFTs will follow in a separate PR