### PR TITLE
Fix loading of custom currencies. Empty list if file not specified.

### DIFF
--- a/cmd/rosetta/config.go
+++ b/cmd/rosetta/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/multiversx/mx-chain-rosetta/server/resources"
@@ -10,14 +11,14 @@ import (
 func loadConfigOfCustomCurrencies(configFile string) ([]resources.Currency, error) {
 	fileContent, err := os.ReadFile(configFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error when reading custom currencies config file: %w", err)
 	}
 
 	var customCurrencies []resources.Currency
 
 	err = json.Unmarshal(fileContent, &customCurrencies)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error when loading custom currencies from file: %w", err)
 	}
 
 	return customCurrencies, nil

--- a/cmd/rosetta/config.go
+++ b/cmd/rosetta/config.go
@@ -8,6 +8,14 @@ import (
 	"github.com/multiversx/mx-chain-rosetta/server/resources"
 )
 
+func decideCustomCurrencies(configFileCustomCurrencies string) ([]resources.Currency, error) {
+	if len(configFileCustomCurrencies) == 0 {
+		return make([]resources.Currency, 0), nil
+	}
+
+	return loadConfigOfCustomCurrencies(configFileCustomCurrencies)
+}
+
 func loadConfigOfCustomCurrencies(configFile string) ([]resources.Currency, error) {
 	fileContent, err := os.ReadFile(configFile)
 	if err != nil {

--- a/cmd/rosetta/config_test.go
+++ b/cmd/rosetta/config_test.go
@@ -26,11 +26,11 @@ func TestLoadConfigOfCustomCurrencies(t *testing.T) {
 
 	t.Run("with error (missing file)", func(t *testing.T) {
 		_, err := loadConfigOfCustomCurrencies("testdata/missing-file.json")
-		require.Error(t, err)
+		require.ErrorContains(t, err, "error when reading custom currencies config file")
 	})
 
 	t.Run("with error (invalid file)", func(t *testing.T) {
 		_, err := loadConfigOfCustomCurrencies("testdata/custom-currencies-bad.json")
-		require.Error(t, err)
+		require.ErrorContains(t, err, "error when loading custom currencies from file")
 	})
 }

--- a/cmd/rosetta/config_test.go
+++ b/cmd/rosetta/config_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDecideCustomCurrencies(t *testing.T) {
+	t.Run("with success (file provided)", func(t *testing.T) {
+		customCurrencies, err := decideCustomCurrencies("testdata/custom-currencies.json")
+		require.NoError(t, err)
+		require.Len(t, customCurrencies, 2)
+	})
+
+	t.Run("with success (file not provided)", func(t *testing.T) {
+		customCurrencies, err := decideCustomCurrencies("")
+		require.NoError(t, err)
+		require.Empty(t, customCurrencies)
+	})
+}
+
 func TestLoadConfigOfCustomCurrencies(t *testing.T) {
 	t.Run("with success", func(t *testing.T) {
 		customCurrencies, err := loadConfigOfCustomCurrencies("testdata/custom-currencies.json")

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/multiversx/mx-chain-rosetta/server/factory"
+	"github.com/multiversx/mx-chain-rosetta/server/resources"
 	"github.com/multiversx/mx-chain-rosetta/version"
 	"github.com/urfave/cli"
 )
@@ -53,7 +54,7 @@ func startRosetta(ctx *cli.Context) error {
 		return err
 	}
 
-	customCurrencies, err := loadConfigOfCustomCurrencies(cliFlags.configFileCustomCurrencies)
+	customCurrencies, err := decideCustomCurrencies(cliFlags.configFileCustomCurrencies)
 	if err != nil {
 		return err
 	}
@@ -121,6 +122,14 @@ func startRosetta(ctx *cli.Context) error {
 	_ = fileLogging.Close()
 
 	return nil
+}
+
+func decideCustomCurrencies(configFileCustomCurrencies string) ([]resources.Currency, error) {
+	if len(configFileCustomCurrencies) == 0 {
+		return make([]resources.Currency, 0), nil
+	}
+
+	return loadConfigOfCustomCurrencies(configFileCustomCurrencies)
 }
 
 func createHttpServer(port int, routers ...server.Router) (*http.Server, error) {

--- a/cmd/rosetta/main.go
+++ b/cmd/rosetta/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/multiversx/mx-chain-rosetta/server/factory"
-	"github.com/multiversx/mx-chain-rosetta/server/resources"
 	"github.com/multiversx/mx-chain-rosetta/version"
 	"github.com/urfave/cli"
 )
@@ -122,14 +121,6 @@ func startRosetta(ctx *cli.Context) error {
 	_ = fileLogging.Close()
 
 	return nil
-}
-
-func decideCustomCurrencies(configFileCustomCurrencies string) ([]resources.Currency, error) {
-	if len(configFileCustomCurrencies) == 0 {
-		return make([]resources.Currency, 0), nil
-	}
-
-	return loadConfigOfCustomCurrencies(configFileCustomCurrencies)
 }
 
 func createHttpServer(port int, routers ...server.Router) (*http.Server, error) {


### PR DESCRIPTION
 - Fix loading of custom currencies. Use an empty list if the config file is not specified.