### PR TITLE
Handle deployments and calls, with value, with signal error

### DIFF
--- a/server/services/testdata/blocks_with_contract_calls.json
+++ b/server/services/testdata/blocks_with_contract_calls.json
@@ -1,0 +1,52 @@
+[
+    {
+        "comment": "block with intra-shard contract call, with move balance, with signal error",
+        "miniBlocks": [
+            {
+                "transactions": [
+                    {
+                        "type": "normal",
+                        "processingTypeOnSource": "SCInvoking",
+                        "processingTypeOnDestination": "SCInvoking",
+                        "hash": "9851ab6cb221bce5800030f9db2a5fbd8ed4a9db4c6f9d190c16113f2b080e57",
+                        "value": "10000000000000000",
+                        "receiver": "erd1qqqqqqqqqqqqqpgqagjekf5mxv86hy5c62vvtug5vc6jmgcsq6uq8reras",
+                        "sender": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                        "sourceShard": 0,
+                        "destinationShard": 0,
+                        "logs": {
+                            "address": "erd1qqqqqqqqqqqqqpgqagjekf5mxv86hy5c62vvtug5vc6jmgcsq6uq8reras",
+                            "events": [
+                                {
+                                    "address": "erd1qqqqqqqqqqqqqpgqagjekf5mxv86hy5c62vvtug5vc6jmgcsq6uq8reras",
+                                    "identifier": "signalError",
+                                    "topics": [
+                                        "XPSryD5QxTCdgH/D9naYh1mh4wEAG8mgJlgE9Cr4Brg=",
+                                        "aW52YWxpZCBmdW5jdGlvbiAobm90IGZvdW5kKQ=="
+                                    ],
+                                    "data": "QDY2NzU2ZTYzNzQ2OTZmNmUyMDZlNmY3NDIwNjY2Zjc1NmU2NA==",
+                                    "additionalData": [
+                                        "QDY2NzU2ZTYzNzQ2OTZmNmUyMDZlNmY3NDIwNjY2Zjc1NmU2NA=="
+                                    ]
+                                },
+                                {
+                                    "address": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                                    "identifier": "internalVMErrors",
+                                    "topics": [
+                                        "AAAAAAAAAAAFAOolmyabMw+rkpjSmMXxFGY1LaMQBrg=",
+                                        "bWlzc2luZ0Z1bmN0aW9u"
+                                    ],
+                                    "data": "CglydW50aW1lLmdvOjgzMSBbaW52YWxpZCBmdW5jdGlvbiAobm90IGZvdW5kKV0gW21pc3NpbmdGdW5jdGlvbl0=",
+                                    "additionalData": [
+                                        "CglydW50aW1lLmdvOjgzMSBbaW52YWxpZCBmdW5jdGlvbiAobm90IGZvdW5kKV0gW21pc3NpbmdGdW5jdGlvbl0="
+                                    ]
+                                }
+                            ]
+                        },
+                        "initiallyPaidFee": "144050000000000"
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/server/services/testdata/blocks_with_contract_deployments.json
+++ b/server/services/testdata/blocks_with_contract_deployments.json
@@ -1,0 +1,98 @@
+[
+    {
+        "comment": "block with contract deployment, with move balance",
+        "miniBlocks": [
+            {
+                "transactions": [
+                    {
+                        "type": "normal",
+                        "processingTypeOnSource": "SCDeployment",
+                        "processingTypeOnDestination": "SCDeployment",
+                        "hash": "2459bb2b9a64c1c920777ecbdaf0fa33d7fe8bcd24d7164562f341b2e4f702da",
+                        "value": "10000000000000000",
+                        "receiver": "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu",
+                        "sender": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                        "logs": {
+                            "address": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                            "events": [
+                                {
+                                    "address": "erd1qqqqqqqqqqqqqpgqc4vdnqgc48ww26ljxqe2flgl86jewg0nq6uqna2ymj",
+                                    "identifier": "SCDeploy",
+                                    "topics": [
+                                        "AAAAAAAAAAAFAMVY2YEYqdzla/IwMqT9Hz6llyHzBrg=",
+                                        "XPSryD5QxTCdgH/D9naYh1mh4wEAG8mgJlgE9Cr4Brg=",
+                                        "v5gJ+IK1KdPGJfGYibrKij1SO0bzAAhfUVsODJ8midg="
+                                    ],
+                                    "data": null,
+                                    "additionalData": null
+                                },
+                                {
+                                    "address": "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu",
+                                    "identifier": "writeLog",
+                                    "topics": [
+                                        "XPSryD5QxTCdgH/D9naYh1mh4wEAG8mgJlgE9Cr4Brg=",
+                                        "QHRvbyBtdWNoIGdhcyBwcm92aWRlZCBmb3IgcHJvY2Vzc2luZzogZ2FzIHByb3ZpZGVkID0gNDU4ODUwMCwgZ2FzIHVzZWQgPSAzMzQ1MDU="
+                                    ],
+                                    "data": "QDZmNmI=",
+                                    "additionalData": ["QDZmNmI="]
+                                }
+                            ]
+                        },
+                        "operation": "scDeploy",
+                        "initiallyPaidFee": "457385000000000"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "comment": "block with contract deployment, with move balance, with signal error",
+        "miniBlocks": [
+            {
+                "transactions": [
+                    {
+                        "type": "normal",
+                        "processingTypeOnSource": "SCDeployment",
+                        "processingTypeOnDestination": "SCDeployment",
+                        "hash": "52b74f025158f18512353da5f23c2e31c78c49d7b73da7d24f048f86da48b5c5",
+                        "value": "77",
+                        "receiver": "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu",
+                        "sender": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                        "sourceShard": 0,
+                        "destinationShard": 0,
+                        "logs": {
+                            "address": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                            "events": [
+                                {
+                                    "address": "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu",
+                                    "identifier": "signalError",
+                                    "topics": [
+                                        "XPSryD5QxTCdgH/D9naYh1mh4wEAG8mgJlgE9Cr4Brg=",
+                                        "ZnVuY3Rpb24gZG9lcyBub3QgYWNjZXB0IEVHTEQgcGF5bWVudA=="
+                                    ],
+                                    "data": "QDY1Nzg2NTYzNzU3NDY5NmY2ZTIwNjY2MTY5NmM2NTY0",
+                                    "additionalData": [
+                                        "QDY1Nzg2NTYzNzU3NDY5NmY2ZTIwNjY2MTY5NmM2NTY0"
+                                    ]
+                                },
+                                {
+                                    "address": "erd1tn62hjp72rznp8vq0lplva5csav6rccpqqdungpxtqz0g2hcq6uq9k4cc6",
+                                    "identifier": "internalVMErrors",
+                                    "topics": [
+                                        "XPSryD5QxTCdgH/D9naYh1mh4wEAG8mgJlgE9Cr4Brg=",
+                                        "X2luaXQ="
+                                    ],
+                                    "data": "CglydW50aW1lLmdvOjgzNCBbZXhlY3V0aW9uIGZhaWxlZF0gW10KCXJ1bnRpbWUuZ286ODM0IFtleGVjdXRpb24gZmFpbGVkXSBbXQoJcnVudGltZS5nbzo4MzEgW2Z1bmN0aW9uIGRvZXMgbm90IGFjY2VwdCBFR0xEIHBheW1lbnRd",
+                                    "additionalData": [
+                                        "CglydW50aW1lLmdvOjgzNCBbZXhlY3V0aW9uIGZhaWxlZF0gW10KCXJ1bnRpbWUuZ286ODM0IFtleGVjdXRpb24gZmFpbGVkXSBbXQoJcnVudGltZS5nbzo4MzEgW2Z1bmN0aW9uIGRvZXMgbm90IGFjY2VwdCBFR0xEIHBheW1lbnRd"
+                                    ]
+                                }
+                            ]
+                        },
+                        "initiallyPaidFee": "2206715000000000"
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/server/services/transactionsFeaturesDetector.go
+++ b/server/services/transactionsFeaturesDetector.go
@@ -74,3 +74,23 @@ func (detector *transactionsFeaturesDetector) isRelayedV1TransactionCompletelyIn
 	isWithSignalError := detector.eventsController.hasAnySignalError(tx)
 	return isWithSignalError
 }
+
+func (detector *transactionsFeaturesDetector) isContractDeploymentWithSignalErrorOrIntrashardContractCallWithSignalError(tx *transaction.ApiTransactionResult) bool {
+	return detector.isContractDeploymentWithSignalError(tx) || (detector.isIntrashard(tx) && detector.isContractCallWithSignalError(tx))
+}
+
+func (detector *transactionsFeaturesDetector) isContractDeploymentWithSignalError(tx *transaction.ApiTransactionResult) bool {
+	return tx.ProcessingTypeOnSource == transactionProcessingTypeContractDeployment &&
+		tx.ProcessingTypeOnDestination == transactionProcessingTypeContractDeployment &&
+		detector.eventsController.hasAnySignalError(tx)
+}
+
+func (detector *transactionsFeaturesDetector) isContractCallWithSignalError(tx *transaction.ApiTransactionResult) bool {
+	return tx.ProcessingTypeOnSource == transactionProcessingTypeContractInvoking &&
+		tx.ProcessingTypeOnDestination == transactionProcessingTypeContractInvoking &&
+		detector.eventsController.hasAnySignalError(tx)
+}
+
+func (detector *transactionsFeaturesDetector) isIntrashard(tx *transaction.ApiTransactionResult) bool {
+	return tx.SourceShard == tx.DestinationShard
+}

--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -177,7 +177,7 @@ func (transformer *transactionsTransformer) normalTxToRosetta(tx *transaction.Ap
 	// Special handling of:
 	// - intra-shard contract calls, bearing value, which fail with signal error
 	// - direct contract deployments, bearing value, which fail with signal error
-	// For these, the protocol does not generate an explicit SCR with the value refund (before Sirius, in some circumstances, it did).
+	// For these, the protocol does not generate an explicit SCR with the value refund (before Sirius, in some cases, it did).
 	// However, since the value remains at the sender, we don't emit any operations in these circumstances.
 	transfersValue := isNonZeroAmount(tx.Value) && !transformer.featuresDetector.isContractDeploymentWithSignalErrorOrIntrashardContractCallWithSignalError(tx)
 	if transfersValue {

--- a/systemtests/check_with_mesh_cli.py
+++ b/systemtests/check_with_mesh_cli.py
@@ -57,11 +57,12 @@ def run_rosetta(configuration: Configuration):
     """
 
     current_epoch = get_current_epoch(configuration)
+    observer_url = configuration.observer_url or constants.URL_OBSERVER_SURROGATE
 
     command = [
         str(constants.PATH_ROSETTA),
         f"--port={constants.PORT_ROSETTA}",
-        f"--observer-http-url={constants.URL_OBSERVER_SURROGATE}",
+        f"--observer-http-url={observer_url}",
         f"--observer-actual-shard={configuration.network_shard}",
         f"--network-id={configuration.network_id}",
         f"--network-name={configuration.network_name}",


### PR DESCRIPTION
Handle:
 - direct contract deployments bearing value, processed with signal error
 - intra-shard contract calls bearing value, processed with signal error.

For these, only the fee operation is emitted.

A possibility for simplification (not yet confirmed): if `for all transactions having a child event of type signal error (direct child event, not of subsequent SCRs), we should only emit the fee operation` is a true statement, we can simplify many portions of the code. However, verifying this statement is postponed.