### PR TITLE
Fix regression: different handling of transactions with signal error before vs. after Sirius

### DIFF
--- a/server/services/transactionsTransformer.go
+++ b/server/services/transactionsTransformer.go
@@ -188,12 +188,17 @@ func (transformer *transactionsTransformer) rewardTxToRosettaTx(tx *transaction.
 func (transformer *transactionsTransformer) normalTxToRosetta(tx *transaction.ApiTransactionResult) (*types.Transaction, error) {
 	operations := make([]*types.Operation, 0)
 
-	// Special handling of:
-	// - intra-shard contract calls, bearing value, which fail with signal error
-	// - direct contract deployments, bearing value, which fail with signal error
-	// For these, the protocol does not generate an explicit SCR with the value refund (before Sirius, in some cases, it did).
-	// However, since the value remains at the sender, we don't emit any operations in these circumstances.
-	transfersValue := isNonZeroAmount(tx.Value) && !transformer.featuresDetector.isContractDeploymentWithSignalErrorOrIntrashardContractCallWithSignalError(tx)
+	transfersValue := isNonZeroAmount(tx.Value)
+
+	if transformer.provider.IsReleaseSiriusActive(tx.Epoch) {
+		// Special handling of:
+		// - intra-shard contract calls, bearing value, which fail with signal error
+		// - direct contract deployments, bearing value, which fail with signal error
+		// For these, the protocol does not generate an explicit SCR with the value refund (before Sirius, in some cases, it did).
+		// However, since the value remains at the sender, we don't emit any operations in these circumstances.
+		transfersValue = transfersValue && !transformer.featuresDetector.isContractDeploymentWithSignalErrorOrIntrashardContractCallWithSignalError(tx)
+	}
+
 	if transfersValue {
 		operations = append(operations, &types.Operation{
 			Type:    opTransfer,


### PR DESCRIPTION
Fix regression of https://github.com/multiversx/mx-chain-rosetta/pull/97.