### PR TITLE
Fix reconcilation failure: improve detection of (in)effective "transfer value only" events

### DIFF
--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -29,7 +29,7 @@ var (
 	durationAlarmThresholdAccountServiceGetAccountBalance = time.Duration(500) * time.Millisecond
 )
 
-var (
+const (
 	transactionEventSignalError                             = core.SignalErrorOperation
 	transactionEventSCDeploy                                = core.SCDeployIdentifier
 	transactionEventTransferValueOnly                       = "transferValueOnly"
@@ -51,7 +51,7 @@ var (
 	transactionEventTransferAndExecute       = "TransferAndExecute"
 )
 
-var (
+const (
 	numTopicsOfEventESDTTransfer                    = 4
 	numTopicsPerTransferOfEventMultiESDTNFTTransfer = 3
 	numTopicsOfEventESDTLocalBurn                   = 3

--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -48,7 +48,7 @@ const (
 
 	transactionEventDataExecuteOnDestContext = "ExecuteOnDestContext"
 	transactionEventDataAsyncCall            = "AsyncCall"
-	transactionEventTransferAndExecute       = "TransferAndExecute"
+	transactionEventDataTransferAndExecute   = "TransferAndExecute"
 )
 
 const (

--- a/server/services/constants.go
+++ b/server/services/constants.go
@@ -48,6 +48,7 @@ var (
 
 	transactionEventDataExecuteOnDestContext = "ExecuteOnDestContext"
 	transactionEventDataAsyncCall            = "AsyncCall"
+	transactionEventTransferAndExecute       = "TransferAndExecute"
 )
 
 var (

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -77,7 +77,8 @@ func (controller *transactionEventsController) decideEffectiveEventTransferValue
 		return nil, nil
 	}
 
-	if string(event.Data) != transactionEventDataExecuteOnDestContext && string(event.Data) != transactionEventDataAsyncCall && string(event.Data) != transactionEventTransferAndExecute {
+	eventData := string(event.Data)
+	if eventData != transactionEventDataExecuteOnDestContext && eventData != transactionEventDataAsyncCall && eventData != transactionEventTransferAndExecute {
 		// Ineffective event, since the balance change is already captured by a SCR.
 		return nil, nil
 	}

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -78,7 +78,7 @@ func (controller *transactionEventsController) decideEffectiveEventTransferValue
 	}
 
 	eventData := string(event.Data)
-	if eventData != transactionEventDataExecuteOnDestContext && eventData != transactionEventDataAsyncCall && eventData != transactionEventTransferAndExecute {
+	if eventData != transactionEventDataExecuteOnDestContext && eventData != transactionEventDataAsyncCall && eventData != transactionEventDataTransferAndExecute {
 		// Ineffective event, since the balance change is already captured by a SCR.
 		return nil, nil
 	}

--- a/server/services/transactionEventsController.go
+++ b/server/services/transactionEventsController.go
@@ -77,7 +77,7 @@ func (controller *transactionEventsController) decideEffectiveEventTransferValue
 		return nil, nil
 	}
 
-	if string(event.Data) != transactionEventDataExecuteOnDestContext && string(event.Data) != transactionEventDataAsyncCall {
+	if string(event.Data) != transactionEventDataExecuteOnDestContext && string(event.Data) != transactionEventDataAsyncCall && string(event.Data) != transactionEventTransferAndExecute {
 		// Ineffective event, since the balance change is already captured by a SCR.
 		return nil, nil
 	}

--- a/server/services/transactionEventsController_test.go
+++ b/server/services/transactionEventsController_test.go
@@ -235,6 +235,35 @@ func TestTransactionEventsController_ExtractEvents(t *testing.T) {
 		require.Equal(t, "100", events[0].value)
 	})
 
+	t.Run("transferValueOnly, after Sirius, effective (intra-shard TransferAndExecute)", func(t *testing.T) {
+		topic0 := big.NewInt(100).Bytes()
+		topic1 := testscommon.TestContractBarShard0.PubKey
+
+		tx := &transaction.ApiTransactionResult{
+			Epoch: 43,
+			Logs: &transaction.ApiLogs{
+				Events: []*transaction.Events{
+					{
+						Identifier: "transferValueOnly",
+						Address:    testscommon.TestContractFooShard0.Address,
+						Topics: [][]byte{
+							topic0,
+							topic1,
+						},
+						Data: []byte("TransferAndExecute"),
+					},
+				},
+			},
+		}
+
+		events, err := controller.extractEventTransferValueOnly(tx)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+		require.Equal(t, testscommon.TestContractFooShard0.Address, events[0].sender)
+		require.Equal(t, testscommon.TestContractBarShard0.Address, events[0].receiver)
+		require.Equal(t, "100", events[0].value)
+	})
+
 	t.Run("transferValueOnly, after Sirius, ineffective (cross-shard AsyncCall)", func(t *testing.T) {
 		topic0 := big.NewInt(100).Bytes()
 		topic1 := testscommon.TestContractBarShard1.PubKey

--- a/systemtests/check_with_mesh_cli.py
+++ b/systemtests/check_with_mesh_cli.py
@@ -76,6 +76,7 @@ def run_rosetta(configuration: Configuration, shard: int):
         f"--first-historical-epoch={current_epoch}",
         f"--num-historical-epochs={configuration.num_historical_epochs}",
         f"--activation-epoch-spica={configuration.activation_epoch_spica}",
+        "--log-level=*:DEBUG",
         "--handle-contracts",
         "--pprof"
     ]

--- a/version/constants.go
+++ b/version/constants.go
@@ -7,5 +7,5 @@ const (
 
 var (
 	// RosettaMiddlewareVersion is the version of this package (application)
-	RosettaMiddlewareVersion = "v0.7.0"
+	RosettaMiddlewareVersion = "v0.7.1"
 )


### PR DESCRIPTION
Original reconciliation failure:

```
Command Failed: unable to sync to 26038290: failed to sequence block range 26035294-26038290: unable to process block range 26035294-26038290: 
unable to process block 26035294: failed to handle the event of block 26035294 is added: unable to add block 26035294 (block hash: e447fbfbfe40e83a24c81f983aeb8271328d482058923979f26dfdd191c512ba) to storage: 
unable to update balance: account balance -24625648702188092 of currency {"symbol":"EGLD","decimals":18} for 

account {"address":"erd1qqqqqqqqqqqqqpgqkcllq2mgrnshhf543ese6gww3y2fjgs6u7zsmq34k6"} at block {"index":26035294,"hash":"e447fbfbfe40e83a24c81f983aeb8271328d482058923979f26dfdd191c512ba"} is invalid: negative balance
```

The `transfer value only` event with value `0.024625648702188092` was previously ignored - mistakenly thought as being ineffective, in the function `decideEffectiveEventTransferValueOnlyAfterSirius`. 

We've changed the logic, so that `transfer value only` events emitted within `ExecuteOnDestContext`, `AsyncCall` and `TransferAndExecute` are properly considered (previously, the latter wasn't).